### PR TITLE
Fix team highlighting MultiBinding converter

### DIFF
--- a/Views/GameView.xaml
+++ b/Views/GameView.xaml
@@ -13,7 +13,8 @@
         <local:CorrectToSymbolConverter x:Key="CorrectToSymbolConverter"/>
         <local:CorrectToBrushConverter x:Key="CorrectToBrushConverter"/>
 
-        <local:ReferenceEqualsConverter x:Key="ReferenceEqualsConverter"/>
+        <!-- Zum Vergleichen der Team-Instanzen wird ein MultiValueConverter benötigt -->
+        <local:ReferenceEqualsMultiConverter x:Key="ReferenceEqualsMultiConverter"/>
     </UserControl.Resources>
 
     <Grid>
@@ -46,9 +47,11 @@
                                         <!-- Ist dieses Item == CurrentTeam ? Dann gold markieren -->
                                         <DataTrigger Value="True">
                                             <DataTrigger.Binding>
-                                                <MultiBinding Converter="{StaticResource ReferenceEqualsConverter}">
+                                                <!-- Vergleich: Ist das aktuelle Item das aktive Team? -->
+                                                <MultiBinding Converter="{StaticResource ReferenceEqualsMultiConverter}">
+                                                    <!-- Dieses Team-Item -->
                                                     <Binding/>
-                                                    <!-- dieses Team-Item -->
+                                                    <!-- Aktuelles Team aus dem ViewModel -->
                                                     <Binding Path="DataContext.CurrentTeam" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
                                                 </MultiBinding>
                                             </DataTrigger.Binding>


### PR DESCRIPTION
## Summary
- Use `ReferenceEqualsMultiConverter` for comparing team instances in `GameView`
- Update trigger to bind current team via `MultiBinding`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a8a0f3e083219c4db00e0d7a68fd