### PR TITLE
Align answer symbols with text

### DIFF
--- a/Views/GameView.xaml
+++ b/Views/GameView.xaml
@@ -161,7 +161,7 @@
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center"
                                                 Visibility="{Binding Revealed, Converter={StaticResource BooleanToVisibilityConverter}}">
                                         <TextBlock Text="{Binding Correct, Converter={StaticResource CorrectToSymbolConverter}}"
-                                                   FontSize="28" Margin="0,4,8,0"/>
+                                                   FontSize="16" Margin="0,0,8,0" VerticalAlignment="Center"/>
                                         <TextBlock Text="{Binding Correct, Converter={StaticResource CorrectToTextConverter}}"
                                                    FontSize="16"/>
                                     </StackPanel>


### PR DESCRIPTION
## Summary
- Ensure checkmark/cross symbols in GameView are the same size as their "richtig"/"Falsch" text so comments remain visible

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2417fab388321b47de7aedb5c1db7