### PR TITLE
Remove revealed field from question data

### DIFF
--- a/Data/questions.json
+++ b/Data/questions.json
@@ -6,506 +6,426 @@
       {
         "Text": "Aspirin",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dieselmotor",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dreifarbdurck",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dynamit",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dynamo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "el. Aufzug",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "el. Lokomotive",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Elektronenr\u00F6hre",
+        "Text": "Elektronenröhre",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Gl\u00FChbirne",
+        "Text": "Glühbirne",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Luftreifen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "R\u00F6ntgenstrahlen",
+        "Text": "Röntgenstrahlen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Segelflugzeug",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Telefon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "U-Boot",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wankelmotor",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zeppelin",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welches Material ist bei 1500\u00B0C fl\u00FCssig?",
+    "Text": "Welches Material ist bei 1500°C flüssig?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Aluminium",
         "Correct": true,
-        "Comment": "658 \u00B0C",
-        "Revealed": false
+        "Comment": "658 °C"
       },
       {
         "Text": "Blei",
         "Correct": true,
-        "Comment": "327 \u00B0C",
-        "Revealed": false
+        "Comment": "327 °C"
       },
       {
         "Text": "Bronze",
         "Correct": true,
-        "Comment": "910 \u00B0C",
-        "Revealed": false
+        "Comment": "910 °C"
       },
       {
         "Text": "Chrom",
         "Correct": false,
-        "Comment": "1800 \u00B0C",
-        "Revealed": false
+        "Comment": "1800 °C"
       },
       {
         "Text": "Eisen",
         "Correct": false,
-        "Comment": "1530 \u00B0C",
-        "Revealed": false
+        "Comment": "1530 °C"
       },
       {
         "Text": "Glas",
         "Correct": true,
-        "Comment": "700 \u00B0C",
-        "Revealed": false
+        "Comment": "700 °C"
       },
       {
         "Text": "Gold",
         "Correct": true,
-        "Comment": "1063 \u00B0C",
-        "Revealed": false
+        "Comment": "1063 °C"
       },
       {
         "Text": "Graphit",
         "Correct": false,
-        "Comment": "3830 \u00B0C",
-        "Revealed": false
+        "Comment": "3830 °C"
       },
       {
         "Text": "Kochsalz",
         "Correct": true,
-        "Comment": "802 \u00B0C",
-        "Revealed": false
+        "Comment": "802 °C"
       },
       {
         "Text": "Kupfer",
         "Correct": true,
-        "Comment": "1083 \u00B0C",
-        "Revealed": false
+        "Comment": "1083 °C"
       },
       {
         "Text": "Marmor",
         "Correct": true,
-        "Comment": "1290 \u00B0C",
-        "Revealed": false
+        "Comment": "1290 °C"
       },
       {
         "Text": "Messing",
         "Correct": true,
-        "Comment": "900 \u00B0C",
-        "Revealed": false
+        "Comment": "900 °C"
       },
       {
         "Text": "Nickel",
         "Correct": true,
-        "Comment": "1452 \u00B0C",
-        "Revealed": false
+        "Comment": "1452 °C"
       },
       {
         "Text": "Platin",
         "Correct": false,
-        "Comment": "1770 \u00B0C",
-        "Revealed": false
+        "Comment": "1770 °C"
       },
       {
         "Text": "Quarz",
         "Correct": true,
-        "Comment": "1400 \u00B0C",
-        "Revealed": false
+        "Comment": "1400 °C"
       },
       {
         "Text": "Stahl",
         "Correct": true,
-        "Comment": "1450 \u00B0C",
-        "Revealed": false
+        "Comment": "1450 °C"
       }
     ]
   },
   {
-    "Text": "Welche Pers\u00F6nlichkeiten arbeiten unter Pseudonym?",
+    "Text": "Welche Persönlichkeiten arbeiten unter Pseudonym?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Franz von Assisi",
         "Correct": true,
-        "Comment": "Giovanni Francesco Bernardone",
-        "Revealed": false
+        "Comment": "Giovanni Francesco Bernardone"
       },
       {
         "Text": "Abraham a Santa Clara",
         "Correct": true,
-        "Comment": "Hans Ulrich Mengerle",
-        "Revealed": false
+        "Comment": "Hans Ulrich Mengerle"
       },
       {
         "Text": "Alexandre Dumas",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Maxim Gorki",
         "Correct": true,
-        "Comment": "Alexei Maximowitsch Peschkow",
-        "Revealed": false
+        "Comment": "Alexei Maximowitsch Peschkow"
       },
       {
         "Text": "Ernest Hemingway",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jack London",
         "Correct": true,
-        "Comment": "John Griffith",
-        "Revealed": false
+        "Comment": "John Griffith"
       },
       {
         "Text": "Gerhardus Mercator",
         "Correct": true,
-        "Comment": "Gerhard Kremer",
-        "Revealed": false
+        "Comment": "Gerhard Kremer"
       },
       {
-        "Text": "Moli\u00E8re",
+        "Text": "Molière",
         "Correct": true,
-        "Comment": "Jean Baptiste Poquelin",
-        "Revealed": false
+        "Comment": "Jean Baptiste Poquelin"
       },
       {
         "Text": "George Orwell",
         "Correct": true,
-        "Comment": "Eric Arthur Blair",
-        "Revealed": false
+        "Comment": "Eric Arthur Blair"
       },
       {
         "Text": "Philippus Aureolis Paracelsus",
         "Correct": true,
-        "Comment": "Theophrastus Bombastus von Hohenheim",
-        "Revealed": false
+        "Comment": "Theophrastus Bombastus von Hohenheim"
       },
       {
         "Text": "Joachim Ringelnatz",
         "Correct": true,
-        "Comment": "Hans B\u00F6tticher",
-        "Revealed": false
+        "Comment": "Hans Bötticher"
       },
       {
         "Text": "Erasmus von Rotterdam",
         "Correct": true,
-        "Comment": "Gerhard Gerhards",
-        "Revealed": false
+        "Comment": "Gerhard Gerhards"
       },
       {
         "Text": "Robert Louis Stevenson",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kurt Tucholsky",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mark Twain",
         "Correct": true,
-        "Comment": "Samuel Laghorne Clemens",
-        "Revealed": false
+        "Comment": "Samuel Laghorne Clemens"
       },
       {
         "Text": "Voltaire",
         "Correct": true,
-        "Comment": "Francois-Maire Arouet",
-        "Revealed": false
+        "Comment": "Francois-Maire Arouet"
       }
     ]
   },
   {
-    "Text": "Welche Namen geh\u00F6ren Inselgruppen?",
+    "Text": "Welche Namen gehören Inselgruppen?",
     "Selected": true,
     "Answers": [
       {
         "Text": "Azoren",
         "Correct": true,
-        "Comment": "zu Portugal: 9 Inseln im Atlantik",
-        "Revealed": false
+        "Comment": "zu Portugal: 9 Inseln im Atlantik"
       },
       {
         "Text": "Balearen",
         "Correct": true,
-        "Comment": "zu Spanien: 4 Inseln im Mittelmeer",
-        "Revealed": false
+        "Comment": "zu Spanien: 4 Inseln im Mittelmeer"
       },
       {
         "Text": "Bengalen",
         "Correct": false,
-        "Comment": "Landschaft in Indien",
-        "Revealed": false
+        "Comment": "Landschaft in Indien"
       },
       {
         "Text": "Hebriden",
         "Correct": true,
-        "Comment": "zu Schottland: ca. 500 Inseln im Atlantik",
-        "Revealed": false
+        "Comment": "zu Schottland: ca. 500 Inseln im Atlantik"
       },
       {
         "Text": "Karawanken",
         "Correct": false,
-        "Comment": "Gebirge bis 2238m (\u00D6sterreich/Kroatien)",
-        "Revealed": false
+        "Comment": "Gebirge bis 2238m (Österreich/Kroatien)"
       },
       {
         "Text": "Komoren",
         "Correct": true,
-        "Comment": "eigene Republik im indischen Ozean",
-        "Revealed": false
+        "Comment": "eigene Republik im indischen Ozean"
       },
       {
         "Text": "Kordilleren",
         "Correct": false,
-        "Comment": "Gebirge in Amerika (=Anden)",
-        "Revealed": false
+        "Comment": "Gebirge in Amerika (=Anden)"
       },
       {
         "Text": "Kurilen",
         "Correct": true,
-        "Comment": "zu Ru\u00DFland: NW von Japan im Pazifik",
-        "Revealed": false
+        "Comment": "zu Rußland: NW von Japan im Pazifik"
       },
       {
         "Text": "Kykladen",
         "Correct": true,
-        "Comment": "zu Griechenland: ca. 200 Inseln im Mittelmeer",
-        "Revealed": false
+        "Comment": "zu Griechenland: ca. 200 Inseln im Mittelmeer"
       },
       {
         "Text": "Lakkadiven",
         "Correct": true,
-        "Comment": "indische Koralleninseln im indischen Ozean",
-        "Revealed": false
+        "Comment": "indische Koralleninseln im indischen Ozean"
       },
       {
         "Text": "Lofoten",
         "Correct": true,
-        "Comment": "zu Norwegen: n\u00F6rdlich des Polarkreises im Atlantik",
-        "Revealed": false
+        "Comment": "zu Norwegen: nördlich des Polarkreises im Atlantik"
       },
       {
         "Text": "Malediven",
         "Correct": true,
-        "Comment": "eigene Republik SW von Ceylon im ind. Ozean",
-        "Revealed": false
+        "Comment": "eigene Republik SW von Ceylon im ind. Ozean"
       },
       {
         "Text": "Molukken",
         "Correct": true,
-        "Comment": "zu Indonesien westlich von Neuguinea im Pazifik",
-        "Revealed": false
+        "Comment": "zu Indonesien westlich von Neuguinea im Pazifik"
       },
       {
         "Text": "Seychellen",
         "Correct": true,
-        "Comment": "eigene Republik n\u00F6rdlich von Madagaskar im ind. Ozean",
-        "Revealed": false
+        "Comment": "eigene Republik nördlich von Madagaskar im ind. Ozean"
       },
       {
         "Text": "Sporaden",
         "Correct": true,
-        "Comment": "zu Griechenland: Inseln in der \u00C4g\u00E4is (Mittelmeer)",
-        "Revealed": false
+        "Comment": "zu Griechenland: Inseln in der Ägäis (Mittelmeer)"
       },
       {
         "Text": "Tamilen",
         "Correct": false,
-        "Comment": "Volksstamm in Indien",
-        "Revealed": false
+        "Comment": "Volksstamm in Indien"
       }
     ]
   },
   {
-    "Text": "Welches Holz ist leichter als Rotbuche (680 g/dm\u00B3)",
+    "Text": "Welches Holz ist leichter als Rotbuche (680 g/dm³)",
     "Selected": true,
     "Answers": [
       {
         "Text": "Ahorn",
         "Correct": true,
-        "Comment": "670 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "670 g/dm³"
       },
       {
         "Text": "Balsa",
         "Correct": true,
-        "Comment": "150 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "150 g/dm³"
       },
       {
         "Text": "Bambus",
         "Correct": false,
-        "Comment": "800 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "800 g/dm³"
       },
       {
         "Text": "Birke",
         "Correct": true,
-        "Comment": "610 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "610 g/dm³"
       },
       {
         "Text": "Bleistiftzeder",
         "Correct": true,
-        "Comment": "580 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "580 g/dm³"
       },
       {
         "Text": "Ebenholz",
         "Correct": false,
-        "Comment": "1080 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "1080 g/dm³"
       },
       {
         "Text": "Erle",
         "Correct": true,
-        "Comment": "490 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "490 g/dm³"
       },
       {
         "Text": "Fichte",
         "Correct": true,
-        "Comment": "420 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "420 g/dm³"
       },
       {
         "Text": "Kastanie",
         "Correct": true,
-        "Comment": "560 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "560 g/dm³"
       },
       {
         "Text": "Kirschbaum",
         "Correct": true,
-        "Comment": "660 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "660 g/dm³"
       },
       {
         "Text": "Linde",
         "Correct": true,
-        "Comment": "530 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "530 g/dm³"
       },
       {
         "Text": "Mahagoni",
         "Correct": false,
-        "Comment": "700 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "700 g/dm³"
       },
       {
         "Text": "Pappel",
         "Correct": true,
-        "Comment": "510 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "510 g/dm³"
       },
       {
         "Text": "Rosenholz",
         "Correct": false,
-        "Comment": "910 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "910 g/dm³"
       },
       {
         "Text": "Tanne",
         "Correct": true,
-        "Comment": "410 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "410 g/dm³"
       },
       {
         "Text": "Ulme",
         "Correct": true,
-        "Comment": "660 g/dm\u00B3",
-        "Revealed": false
+        "Comment": "660 g/dm³"
       }
     ]
   },
@@ -514,202 +434,170 @@
     "Selected": true,
     "Answers": [
       {
-        "Text": "B\u00E4r",
+        "Text": "Bär",
         "Correct": true,
-        "Comment": "8 Monate",
-        "Revealed": false
+        "Comment": "8 Monate"
       },
       {
         "Text": "Dachs",
         "Correct": true,
-        "Comment": "5 Monate",
-        "Revealed": false
+        "Comment": "5 Monate"
       },
       {
         "Text": "Elefant",
         "Correct": false,
-        "Comment": "22 Monate",
-        "Revealed": false
+        "Comment": "22 Monate"
       },
       {
         "Text": "Giraffe",
         "Correct": false,
-        "Comment": "14 Monate",
-        "Revealed": false
+        "Comment": "14 Monate"
       },
       {
         "Text": "Hamster",
         "Correct": true,
-        "Comment": "20 Tage",
-        "Revealed": false
+        "Comment": "20 Tage"
       },
       {
         "Text": "Igel",
         "Correct": true,
-        "Comment": "50 Tage",
-        "Revealed": false
+        "Comment": "50 Tage"
       },
       {
-        "Text": "K\u00E4nguruh",
+        "Text": "Känguruh",
         "Correct": true,
-        "Comment": "39 Tage",
-        "Revealed": false
+        "Comment": "39 Tage"
       },
       {
         "Text": "Kaninchen",
         "Correct": true,
-        "Comment": "1 Monat",
-        "Revealed": false
+        "Comment": "1 Monat"
       },
       {
         "Text": "Katze",
         "Correct": true,
-        "Comment": "2 Monate",
-        "Revealed": false
+        "Comment": "2 Monate"
       },
       {
         "Text": "Kuh",
         "Correct": false,
-        "Comment": "9,5 Monate",
-        "Revealed": false
+        "Comment": "9,5 Monate"
       },
       {
-        "Text": "L\u00F6we",
+        "Text": "Löwe",
         "Correct": true,
-        "Comment": "3,5 Monate",
-        "Revealed": false
+        "Comment": "3,5 Monate"
       },
       {
         "Text": "Pferd",
         "Correct": false,
-        "Comment": "11,2 Monate",
-        "Revealed": false
+        "Comment": "11,2 Monate"
       },
       {
         "Text": "Schaf",
         "Correct": true,
-        "Comment": "5,3 Monate",
-        "Revealed": false
+        "Comment": "5,3 Monate"
       },
       {
         "Text": "Schwein",
         "Correct": true,
-        "Comment": "4 Monate",
-        "Revealed": false
+        "Comment": "4 Monate"
       },
       {
         "Text": "Wolf",
         "Correct": true,
-        "Comment": "2,1 Monate",
-        "Revealed": false
+        "Comment": "2,1 Monate"
       },
       {
         "Text": "Ziege",
         "Correct": true,
-        "Comment": "5,3 Monate",
-        "Revealed": false
+        "Comment": "5,3 Monate"
       }
     ]
   },
   {
-    "Text": "Welche Pflanzen sind nach Deutschland \u201Eeingewandert\u201C?",
+    "Text": "Welche Pflanzen sind nach Deutschland „eingewandert“?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Apfel",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Erdbeere",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gurke",
         "Correct": true,
-        "Comment": "Indien",
-        "Revealed": false
+        "Comment": "Indien"
       },
       {
         "Text": "Hafer",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hirse",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kartoffel",
         "Correct": true,
-        "Comment": "Peru",
-        "Revealed": false
+        "Comment": "Peru"
       },
       {
-        "Text": "K\u00FCrbis",
+        "Text": "Kürbis",
         "Correct": true,
-        "Comment": "Amerika",
-        "Revealed": false
+        "Comment": "Amerika"
       },
       {
         "Text": "Mais",
         "Correct": true,
-        "Comment": "Amerika",
-        "Revealed": false
+        "Comment": "Amerika"
       },
       {
         "Text": "Pflaume",
         "Correct": true,
-        "Comment": "Kaukasus",
-        "Revealed": false
+        "Comment": "Kaukasus"
       },
       {
         "Text": "Quitte",
         "Correct": true,
-        "Comment": "Kreta",
-        "Revealed": false
+        "Comment": "Kreta"
       },
       {
         "Text": "Rose",
         "Correct": true,
-        "Comment": "Orient",
-        "Revealed": false
+        "Comment": "Orient"
       },
       {
         "Text": "Sauerkirsche",
         "Correct": true,
-        "Comment": "Kleinasien",
-        "Revealed": false
+        "Comment": "Kleinasien"
       },
       {
         "Text": "Tabak",
         "Correct": true,
-        "Comment": "Amerika",
-        "Revealed": false
+        "Comment": "Amerika"
       },
       {
         "Text": "Tomate",
         "Correct": true,
-        "Comment": "Peru",
-        "Revealed": false
+        "Comment": "Peru"
       },
       {
         "Text": "Wein",
         "Correct": true,
-        "Comment": "Nordeuropa",
-        "Revealed": false
+        "Comment": "Nordeuropa"
       },
       {
         "Text": "Weizen",
         "Correct": true,
-        "Comment": "Asien",
-        "Revealed": false
+        "Comment": "Asien"
       }
     ]
   },
@@ -718,712 +606,600 @@
     "Selected": false,
     "Answers": [
       {
-        "Text": "Alexander N\u00FCbel",
+        "Text": "Alexander Nübel",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       },
       {
         "Text": "Dennis Seimen",
         "Correct": true,
-        "Comment": "",
-        "Revealed": false
+        "Comment": ""
       },
       {
         "Text": "Fabian Bredlow",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       },
       {
         "Text": "Pascal Stenzel",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       },
       {
         "Text": "Josha Vagnoman",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       },
       {
-        "Text": "Maximilian Mittelst\u00E4dt",
+        "Text": "Maximilian Mittelstädt",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       },
       {
         "Text": "Dan-Axel Zagadou",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       },
       {
         "Text": "Jeff Chabot",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       },
       {
         "Text": "Leonidas Stergiou",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       },
       {
         "Text": "Enzo Millot",
         "Correct": false,
-        "Comment": "Abgang August 2025",
-        "Revealed": false
+        "Comment": "Abgang August 2025"
       },
       {
         "Text": "Angelo Stiller",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       },
       {
         "Text": "Atakan Karazor",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       },
       {
-        "Text": "Chris F\u00FChrich",
+        "Text": "Chris Führich",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       },
       {
         "Text": "Wahid Faghir",
         "Correct": true,
-        "Comment": "Abgang Juli 25",
-        "Revealed": false
+        "Comment": "Abgang Juli 25"
       },
       {
         "Text": "Yannik Keitel",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       },
       {
         "Text": "Deniz Undav",
         "Correct": true,
-        "Comment": "Stand: 08/2025 \u2013 VfB-Kader 2024/25",
-        "Revealed": false
+        "Comment": "Stand: 08/2025 – VfB-Kader 2024/25"
       }
     ]
   },
   {
-    "Text": "Rein theoretisch: Welcher Berg mu\u00DF zum Matterhorn aufschauen (4.478 m)",
+    "Text": "Rein theoretisch: Welcher Berg muß zum Matterhorn aufschauen (4.478 m)",
     "Selected": true,
     "Answers": [
       {
         "Text": "Aconcagua",
         "Correct": false,
-        "Comment": "Argentinien  6,960 m",
-        "Revealed": false
+        "Comment": "Argentinien  6,960 m"
       },
       {
-        "Text": "\u00C4thna",
+        "Text": "Äthna",
         "Correct": true,
-        "Comment": "Sizilien (Italien) 3.323 m",
-        "Revealed": false
+        "Comment": "Sizilien (Italien) 3.323 m"
       },
       {
         "Text": "Dufourspitze",
         "Correct": true,
-        "Comment": "Walliser Alpen 4.634 m",
-        "Revealed": false
+        "Comment": "Walliser Alpen 4.634 m"
       },
       {
         "Text": "Eiger",
         "Correct": true,
-        "Comment": "Schweiz 3.970 m",
-        "Revealed": false
+        "Comment": "Schweiz 3.970 m"
       },
       {
         "Text": "Eyers Rock",
         "Correct": true,
-        "Comment": "Australien 867 m",
-        "Revealed": false
+        "Comment": "Australien 867 m"
       },
       {
-        "Text": "Gro\u00DFglockner",
+        "Text": "Großglockner",
         "Correct": true,
-        "Comment": "\u00D6sterreich 3.798 m",
-        "Revealed": false
+        "Comment": "Österreich 3.798 m"
       },
       {
         "Text": "Jungfrau",
         "Correct": true,
-        "Comment": "Schweiz 4.158 m",
-        "Revealed": false
+        "Comment": "Schweiz 4.158 m"
       },
       {
         "Text": "Kilimandjaro",
         "Correct": false,
-        "Comment": "Tansania 5.895 m",
-        "Revealed": false
+        "Comment": "Tansania 5.895 m"
       },
       {
         "Text": "Mont Blanc",
         "Correct": false,
-        "Comment": "Frankreich / Italien 4.810 m",
-        "Revealed": false
+        "Comment": "Frankreich / Italien 4.810 m"
       },
       {
         "Text": "Monte Rosa",
         "Correct": true,
-        "Comment": "Schweiz / Italien 4.634 m",
-        "Revealed": false
+        "Comment": "Schweiz / Italien 4.634 m"
       },
       {
         "Text": "Mount Everest",
         "Correct": false,
-        "Comment": "Himalaya 8.850 m",
-        "Revealed": false
+        "Comment": "Himalaya 8.850 m"
       },
       {
         "Text": "Olymp",
         "Correct": true,
-        "Comment": "Griechenland 2.917 m",
-        "Revealed": false
+        "Comment": "Griechenland 2.917 m"
       },
       {
         "Text": "Ortler",
         "Correct": true,
-        "Comment": "Italien 3.899 m",
-        "Revealed": false
+        "Comment": "Italien 3.899 m"
       },
       {
         "Text": "Piz Bernina",
         "Correct": true,
-        "Comment": "Schweiz 4.049 m",
-        "Revealed": false
+        "Comment": "Schweiz 4.049 m"
       },
       {
         "Text": "Tafelberg (Kapstadt)",
         "Correct": true,
-        "Comment": "S\u00FCdafrika Kapstadt 1.086 m",
-        "Revealed": false
+        "Comment": "Südafrika Kapstadt 1.086 m"
       },
       {
         "Text": "Zugspitze",
         "Correct": true,
-        "Comment": "Deutschland fast 3.000 m",
-        "Revealed": false
+        "Comment": "Deutschland fast 3.000 m"
       }
     ]
   },
   {
-    "Text": "Siegerinnen beim Filderst\u00E4dter Tennis Grand Prix seit 1978",
+    "Text": "Siegerinnen beim Filderstädter Tennis Grand Prix seit 1978",
     "Selected": false,
     "Answers": [
       {
         "Text": "Martina Hingis",
         "Correct": true,
-        "Comment": "1996, 1997, 1999, 2000",
-        "Revealed": false
+        "Comment": "1996, 1997, 1999, 2000"
       },
       {
         "Text": "Anke Huber",
         "Correct": true,
-        "Comment": "1991 \u002B 1994",
-        "Revealed": false
+        "Comment": "1991 + 1994"
       },
       {
         "Text": "Gabriela Sabatini",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hanna Mandlikova",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Iva Majoli",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Justine Henin",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kim Clijsters",
         "Correct": true,
-        "Comment": "2002 \u002B 2003",
-        "Revealed": false
+        "Comment": "2002 + 2003"
       },
       {
         "Text": "Lindsay Davenport",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Martina Navratilova",
         "Correct": true,
-        "Comment": "insgesamt 6 mal!",
-        "Revealed": false
+        "Comment": "insgesamt 6 mal!"
       },
       {
         "Text": "Mary Joe Fernandez",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mary Pierce",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Natasha Zvereva",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pam Shriver",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sandrine Testude",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Steffie Graf",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tracy Austin",
         "Correct": true,
-        "Comment": "1978 - 1981",
-        "Revealed": false
+        "Comment": "1978 - 1981"
       }
     ]
   },
   {
-    "Text": "In welchen Staatsflaggen ist die Farbe \u0022Rot\u0022 enthalten?",
+    "Text": "In welchen Staatsflaggen ist die Farbe \"Rot\" enthalten?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Afghanistan",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Albanien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Andorra",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Griechenland",
         "Correct": false,
-        "Comment": "Blau mit Kreuz",
-        "Revealed": false
+        "Comment": "Blau mit Kreuz"
       },
       {
         "Text": "Indien",
         "Correct": false,
-        "Comment": "Orange, Weiss, Gr\u00FCn",
-        "Revealed": false
+        "Comment": "Orange, Weiss, Grün"
       },
       {
         "Text": "Indonesien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Israel",
         "Correct": false,
-        "Comment": "Blau mit Stern",
-        "Revealed": false
+        "Comment": "Blau mit Stern"
       },
       {
         "Text": "Monaco",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Norwegen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "\u00D6sterreich",
+        "Text": "Österreich",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pakistan",
         "Correct": false,
-        "Comment": "Gr\u00FCn mit Halbmond",
-        "Revealed": false
+        "Comment": "Grün mit Halbmond"
       },
       {
         "Text": "Philippinen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Polen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "S\u00FCd Korea",
+        "Text": "Süd Korea",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Thailand",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ungarn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "St\u00E4dte mit weniger als 550.000 Einwohnern",
+    "Text": "Städte mit weniger als 550.000 Einwohnern",
     "Selected": false,
     "Answers": [
       {
         "Text": "Bielefeld",
         "Correct": true,
-        "Comment": "331.605 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "331.605 (Stand: 08/2025)"
       },
       {
         "Text": "Bonn",
         "Correct": true,
-        "Comment": "323.336 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "323.336 (Stand: 08/2025)"
       },
       {
         "Text": "Dortmund",
         "Correct": false,
-        "Comment": "614.495 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "614.495 (Stand: 08/2025)"
       },
       {
         "Text": "Dresden",
         "Correct": false,
-        "Comment": "573.648 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "573.648 (Stand: 08/2025)"
       },
       {
         "Text": "Duisburg",
         "Correct": true,
-        "Comment": "507.876 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "507.876 (Stand: 08/2025)"
       },
       {
-        "Text": "D\u00FCsseldorf",
+        "Text": "Düsseldorf",
         "Correct": false,
-        "Comment": "658.245 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "658.245 (Stand: 08/2025)"
       },
       {
         "Text": "Essen",
         "Correct": false,
-        "Comment": "596.973 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "596.973 (Stand: 08/2025)"
       },
       {
         "Text": "Hannover",
         "Correct": true,
-        "Comment": "548.200 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "548.200 (Stand: 08/2025)"
       },
       {
         "Text": "Kassel",
         "Correct": true,
-        "Comment": "207.863 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "207.863 (Stand: 08/2025)"
       },
       {
         "Text": "Kiel",
         "Correct": true,
-        "Comment": "251.379 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "251.379 (Stand: 08/2025)"
       },
       {
         "Text": "Leipzig",
         "Correct": false,
-        "Comment": "632.562 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "632.562 (Stand: 08/2025)"
       },
       {
         "Text": "Mannheim",
         "Correct": true,
-        "Comment": "330.896 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "330.896 (Stand: 08/2025)"
       },
       {
-        "Text": "N\u00FCrnberg",
+        "Text": "Nürnberg",
         "Correct": true,
-        "Comment": "546.576 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "546.576 (Stand: 08/2025)"
       },
       {
         "Text": "Rostock",
         "Correct": true,
-        "Comment": "211.645 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "211.645 (Stand: 08/2025)"
       },
       {
         "Text": "Stuttgart",
         "Correct": false,
-        "Comment": "607.000 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "607.000 (Stand: 08/2025)"
       },
       {
         "Text": "Wuppertal",
         "Correct": true,
-        "Comment": "365.655 (Stand: 08/2025)",
-        "Revealed": false
+        "Comment": "365.655 (Stand: 08/2025)"
       }
     ]
   },
   {
-    "Text": "L\u00E4nder mit mehr als 5 Millionen angemeldeten PKW\u00B4s",
+    "Text": "Länder mit mehr als 5 Millionen angemeldeten PKW´s",
     "Selected": false,
     "Answers": [
       {
         "Text": "Australien",
         "Correct": true,
-        "Comment": "8,879 Mio.",
-        "Revealed": false
+        "Comment": "8,879 Mio."
       },
       {
         "Text": "Brasilien",
         "Correct": true,
-        "Comment": "13,400 Mio.",
-        "Revealed": false
+        "Comment": "13,400 Mio."
       },
       {
         "Text": "Deutschland",
         "Correct": true,
-        "Comment": "40,988 Mio.",
-        "Revealed": false
+        "Comment": "40,988 Mio."
       },
       {
         "Text": "Frankreich",
         "Correct": true,
-        "Comment": "25,500 Mio.",
-        "Revealed": false
+        "Comment": "25,500 Mio."
       },
       {
-        "Text": "Gro\u00DFbritannien",
+        "Text": "Großbritannien",
         "Correct": true,
-        "Comment": "21,092 Mio.",
-        "Revealed": false
+        "Comment": "21,092 Mio."
       },
       {
         "Text": "Indien",
         "Correct": false,
-        "Comment": "4,065 Mio.",
-        "Revealed": false
+        "Comment": "4,065 Mio."
       },
       {
         "Text": "Italien",
         "Correct": true,
-        "Comment": "32,789 Mio.",
-        "Revealed": false
+        "Comment": "32,789 Mio."
       },
       {
         "Text": "Kanada",
         "Correct": true,
-        "Comment": "13,183 Mio.",
-        "Revealed": false
+        "Comment": "13,183 Mio."
       },
       {
         "Text": "Mexiko",
         "Correct": true,
-        "Comment": "8,607 Mio.",
-        "Revealed": false
+        "Comment": "8,607 Mio."
       },
       {
         "Text": "Niederlande",
         "Correct": true,
-        "Comment": "5,636 Mio.",
-        "Revealed": false
+        "Comment": "5,636 Mio."
       },
       {
-        "Text": "\u00D6sterreich",
+        "Text": "Österreich",
         "Correct": false,
-        "Comment": "3,691 Mio.",
-        "Revealed": false
+        "Comment": "3,691 Mio."
       },
       {
         "Text": "Polen",
         "Correct": true,
-        "Comment": "8,054 Mio.",
-        "Revealed": false
+        "Comment": "8,054 Mio."
       },
       {
         "Text": "Schweiz",
         "Correct": false,
-        "Comment": "3,268 Mio.",
-        "Revealed": false
+        "Comment": "3,268 Mio."
       },
       {
         "Text": "Spanien",
         "Correct": true,
-        "Comment": "14,754 Mio.",
-        "Revealed": false
+        "Comment": "14,754 Mio."
       },
       {
-        "Text": "S\u00FCdkorea",
+        "Text": "Südkorea",
         "Correct": true,
-        "Comment": "6,894 Mio.",
-        "Revealed": false
+        "Comment": "6,894 Mio."
       },
       {
         "Text": "VR China",
         "Correct": false,
-        "Comment": "3,894 Mio.",
-        "Revealed": false
+        "Comment": "3,894 Mio."
       }
     ]
   },
   {
-    "Text": "Personen die zur Zeit Mose lebten (pers\u00F6nlicher Kontakt)",
+    "Text": "Personen die zur Zeit Mose lebten (persönlicher Kontakt)",
     "Selected": false,
     "Answers": [
       {
         "Text": "Aaron",
         "Correct": true,
-        "Comment": "Bruder",
-        "Revealed": false
+        "Comment": "Bruder"
       },
       {
         "Text": "Abihu",
         "Correct": true,
-        "Comment": "Priester",
-        "Revealed": false
+        "Comment": "Priester"
       },
       {
         "Text": "Amon",
         "Correct": false,
-        "Comment": "K\u00F6nig Israels",
-        "Revealed": false
+        "Comment": "König Israels"
       },
       {
         "Text": "Amram",
         "Correct": true,
-        "Comment": "Vater",
-        "Revealed": false
+        "Comment": "Vater"
       },
       {
         "Text": "Bileam",
         "Correct": true,
-        "Comment": "Prophet",
-        "Revealed": false
+        "Comment": "Prophet"
       },
       {
         "Text": "Gaddi",
         "Correct": true,
-        "Comment": "Kundschafter",
-        "Revealed": false
+        "Comment": "Kundschafter"
       },
       {
         "Text": "Jakob",
         "Correct": false,
-        "Comment": "Erzvater",
-        "Revealed": false
+        "Comment": "Erzvater"
       },
       {
         "Text": "Jitros",
         "Correct": true,
-        "Comment": "Schwiegervater",
-        "Revealed": false
+        "Comment": "Schwiegervater"
       },
       {
         "Text": "Josua",
         "Correct": true,
-        "Comment": "Nachfolger",
-        "Revealed": false
+        "Comment": "Nachfolger"
       },
       {
         "Text": "Kaleb",
         "Correct": true,
-        "Comment": "Kundschafter",
-        "Revealed": false
+        "Comment": "Kundschafter"
       },
       {
         "Text": "Korach",
         "Correct": true,
-        "Comment": "Aufr\u00FChrer",
-        "Revealed": false
+        "Comment": "Aufrührer"
       },
       {
         "Text": "Levi",
         "Correct": false,
-        "Comment": "er kam aus dem Stamm Levi",
-        "Revealed": false
+        "Comment": "er kam aus dem Stamm Levi"
       },
       {
         "Text": "Michal",
         "Correct": false,
-        "Comment": "Frau von David",
-        "Revealed": false
+        "Comment": "Frau von David"
       },
       {
         "Text": "Mirjam",
         "Correct": true,
-        "Comment": "Schwester",
-        "Revealed": false
+        "Comment": "Schwester"
       },
       {
         "Text": "Nadab",
         "Correct": true,
-        "Comment": "Priester",
-        "Revealed": false
+        "Comment": "Priester"
       },
       {
         "Text": "Zippora",
         "Correct": true,
-        "Comment": "Frau",
-        "Revealed": false
+        "Comment": "Frau"
       }
     ]
   },
@@ -1434,506 +1210,426 @@
       {
         "Text": "Berenike",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Debora",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Elisabeth",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Eunike",
         "Correct": true,
-        "Comment": "Mutter von Timotheus",
-        "Revealed": false
+        "Comment": "Mutter von Timotheus"
       },
       {
         "Text": "Hanna",
         "Correct": true,
-        "Comment": "im Tempel",
-        "Revealed": false
+        "Comment": "im Tempel"
       },
       {
         "Text": "Herodias",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Isolde",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lydia",
         "Correct": true,
-        "Comment": "Purpurverk\u00E4uferin",
-        "Revealed": false
+        "Comment": "Purpurverkäuferin"
       },
       {
         "Text": "M. Magdalena",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Marta",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Ph\u00F6be",
+        "Text": "Phöbe",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Priszilla",
         "Correct": true,
-        "Comment": "Aquilas Frau",
-        "Revealed": false
+        "Comment": "Aquilas Frau"
       },
       {
         "Text": "Sabina",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Salome",
         "Correct": true,
-        "Comment": "Mutter des Jakobus",
-        "Revealed": false
+        "Comment": "Mutter des Jakobus"
       },
       {
         "Text": "Sara",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tabita",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche der folgenden B\u00FCcher des AT k\u00FCndigen den Messias an?",
+    "Text": "Welche der folgenden Bücher des AT kündigen den Messias an?",
     "Selected": false,
     "Answers": [
       {
         "Text": "1. Mose",
         "Correct": true,
-        "Comment": "1. Mose 3,15",
-        "Revealed": false
+        "Comment": "1. Mose 3,15"
       },
       {
         "Text": "4. Mose",
         "Correct": true,
-        "Comment": "4. Mose 24,17",
-        "Revealed": false
+        "Comment": "4. Mose 24,17"
       },
       {
         "Text": "5. Mose",
         "Correct": true,
-        "Comment": "5. Mose 18,15",
-        "Revealed": false
+        "Comment": "5. Mose 18,15"
       },
       {
         "Text": "Esther",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Psalm 22",
         "Correct": true,
-        "Comment": "Leiden Jesus am Kreuz",
-        "Revealed": false
+        "Comment": "Leiden Jesus am Kreuz"
       },
       {
         "Text": "Psalm 117",
         "Correct": false,
-        "Comment": "k\u00FCrzester Psalm der Bibel",
-        "Revealed": false
+        "Comment": "kürzester Psalm der Bibel"
       },
       {
-        "Text": "Spr\u00FCche",
+        "Text": "Sprüche",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jesaja 53",
         "Correct": true,
-        "Comment": "bekanntestes Kapitel",
-        "Revealed": false
+        "Comment": "bekanntestes Kapitel"
       },
       {
         "Text": "Jesaja 61",
         "Correct": true,
-        "Comment": "Lukas 4 (Geist d. Herrn)",
-        "Revealed": false
+        "Comment": "Lukas 4 (Geist d. Herrn)"
       },
       {
         "Text": "Jeremia",
         "Correct": true,
-        "Comment": "Kap. 23,5",
-        "Revealed": false
+        "Comment": "Kap. 23,5"
       },
       {
         "Text": "Hosea",
         "Correct": true,
-        "Comment": "Hos 11,1",
-        "Revealed": false
+        "Comment": "Hos 11,1"
       },
       {
         "Text": "Micha",
         "Correct": true,
-        "Comment": "Micha 5,1",
-        "Revealed": false
+        "Comment": "Micha 5,1"
       },
       {
         "Text": "Nahum",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Haggai",
         "Correct": true,
-        "Comment": "Kap. 2,7",
-        "Revealed": false
+        "Comment": "Kap. 2,7"
       },
       {
         "Text": "Sacharia",
         "Correct": true,
-        "Comment": "viele z.B. 9,9",
-        "Revealed": false
+        "Comment": "viele z.B. 9,9"
       },
       {
         "Text": "Maleachi",
         "Correct": true,
-        "Comment": "Mal. 3,1",
-        "Revealed": false
+        "Comment": "Mal. 3,1"
       }
     ]
   },
   {
-    "Text": "Welche Namen geh\u00F6ren zu Volksgruppen?",
+    "Text": "Welche Namen gehören zu Volksgruppen?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Angolonen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Esten",
         "Correct": true,
-        "Comment": "Esland",
-        "Revealed": false
+        "Comment": "Esland"
       },
       {
         "Text": "Flamen",
         "Correct": true,
-        "Comment": "Belgien",
-        "Revealed": false
+        "Comment": "Belgien"
       },
       {
         "Text": "Haschimiden",
         "Correct": true,
-        "Comment": "Jordanien",
-        "Revealed": false
+        "Comment": "Jordanien"
       },
       {
         "Text": "Inka",
         "Correct": true,
-        "Comment": "Peru",
-        "Revealed": false
+        "Comment": "Peru"
       },
       {
         "Text": "Kasachstanier",
         "Correct": false,
-        "Comment": "hei\u00DFen: Kasachen",
-        "Revealed": false
+        "Comment": "heißen: Kasachen"
       },
       {
         "Text": "Khmer",
         "Correct": true,
-        "Comment": "aus Kambotscha",
-        "Revealed": false
+        "Comment": "aus Kambotscha"
       },
       {
         "Text": "Malagenen",
         "Correct": false,
-        "Comment": "Bl\u00F6dsinn",
-        "Revealed": false
+        "Comment": "Blödsinn"
       },
       {
         "Text": "Mongolen",
         "Correct": true,
-        "Comment": "Mongulei",
-        "Revealed": false
+        "Comment": "Mongulei"
       },
       {
         "Text": "Osseten",
         "Correct": true,
-        "Comment": "aus Georgien",
-        "Revealed": false
+        "Comment": "aus Georgien"
       },
       {
         "Text": "Perser",
         "Correct": true,
-        "Comment": "Iran",
-        "Revealed": false
+        "Comment": "Iran"
       },
       {
         "Text": "Singhalesen",
         "Correct": true,
-        "Comment": "Sri Lanka",
-        "Revealed": false
+        "Comment": "Sri Lanka"
       },
       {
         "Text": "Sorben",
         "Correct": true,
-        "Comment": "slavische Volksgr. In Deutschland",
-        "Revealed": false
+        "Comment": "slavische Volksgr. In Deutschland"
       },
       {
         "Text": "Thainesen",
         "Correct": false,
-        "Comment": "Siamesen oder Thai",
-        "Revealed": false
+        "Comment": "Siamesen oder Thai"
       },
       {
         "Text": "Waliser",
         "Correct": true,
-        "Comment": "Wales",
-        "Revealed": false
+        "Comment": "Wales"
       },
       {
         "Text": "Wallonen",
         "Correct": true,
-        "Comment": "S\u00FCdbelgier",
-        "Revealed": false
+        "Comment": "Südbelgier"
       }
     ]
   },
   {
-    "Text": "Welche der folgenden St\u00E4dte sind Hauptst\u00E4dte?",
+    "Text": "Welche der folgenden Städte sind Hauptstädte?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Amsterdam",
         "Correct": true,
-        "Comment": "Niederlande",
-        "Revealed": false
+        "Comment": "Niederlande"
       },
       {
         "Text": "Barcelona",
         "Correct": false,
-        "Comment": "Spanien: Madrid",
-        "Revealed": false
+        "Comment": "Spanien: Madrid"
       },
       {
         "Text": "Bern",
         "Correct": true,
-        "Comment": "Schweiz",
-        "Revealed": false
+        "Comment": "Schweiz"
       },
       {
         "Text": "Bombay",
         "Correct": false,
-        "Comment": "Indien: Neu-Dehli",
-        "Revealed": false
+        "Comment": "Indien: Neu-Dehli"
       },
       {
         "Text": "Damaskus",
         "Correct": true,
-        "Comment": "Syrien",
-        "Revealed": false
+        "Comment": "Syrien"
       },
       {
         "Text": "Istanbul",
         "Correct": false,
-        "Comment": "T\u00FCrkei: Ankara",
-        "Revealed": false
+        "Comment": "Türkei: Ankara"
       },
       {
         "Text": "Jaunde",
         "Correct": true,
-        "Comment": "Kamarun",
-        "Revealed": false
+        "Comment": "Kamarun"
       },
       {
         "Text": "Kabul",
         "Correct": true,
-        "Comment": "Afganistan",
-        "Revealed": false
+        "Comment": "Afganistan"
       },
       {
         "Text": "Manila",
         "Correct": true,
-        "Comment": "Philipien",
-        "Revealed": false
+        "Comment": "Philipien"
       },
       {
         "Text": "Montevideo",
         "Correct": true,
-        "Comment": "Uruguay",
-        "Revealed": false
+        "Comment": "Uruguay"
       },
       {
         "Text": "Nairobi",
         "Correct": true,
-        "Comment": "KENIA",
-        "Revealed": false
+        "Comment": "KENIA"
       },
       {
         "Text": "Ottawa",
         "Correct": true,
-        "Comment": "Kanada",
-        "Revealed": false
+        "Comment": "Kanada"
       },
       {
         "Text": "Rio de Janeiro",
         "Correct": false,
-        "Comment": "Brasilien: Brasilia",
-        "Revealed": false
+        "Comment": "Brasilien: Brasilia"
       },
       {
         "Text": "Tiflis",
         "Correct": true,
-        "Comment": "Georgien",
-        "Revealed": false
+        "Comment": "Georgien"
       },
       {
         "Text": "Tirana",
         "Correct": true,
-        "Comment": "Albanien",
-        "Revealed": false
+        "Comment": "Albanien"
       },
       {
         "Text": "Warschau",
         "Correct": true,
-        "Comment": "Polen",
-        "Revealed": false
+        "Comment": "Polen"
       }
     ]
   },
   {
-    "Text": "Welche L\u00E4nder sind kleiner als Deutschland (357.022 km\u00B2)?",
+    "Text": "Welche Länder sind kleiner als Deutschland (357.022 km²)?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Angola",
         "Correct": false,
-        "Comment": "1.246.700 km\u00B2",
-        "Revealed": false
+        "Comment": "1.246.700 km²"
       },
       {
         "Text": "Griechenland",
         "Correct": true,
-        "Comment": "131.957 km\u00B2",
-        "Revealed": false
+        "Comment": "131.957 km²"
       },
       {
-        "Text": "Gro\u00DFbritannien",
+        "Text": "Großbritannien",
         "Correct": true,
-        "Comment": "242.900 km\u00B2",
-        "Revealed": false
+        "Comment": "242.900 km²"
       },
       {
         "Text": "Israel",
         "Correct": true,
-        "Comment": "20.991 km\u00B2",
-        "Revealed": false
+        "Comment": "20.991 km²"
       },
       {
         "Text": "Jemen",
         "Correct": false,
-        "Comment": "536.869 km\u00B2",
-        "Revealed": false
+        "Comment": "536.869 km²"
       },
       {
         "Text": "Kasachstan",
         "Correct": false,
-        "Comment": "2.717.300 km\u00B2",
-        "Revealed": false
+        "Comment": "2.717.300 km²"
       },
       {
         "Text": "Kuwait",
         "Correct": true,
-        "Comment": "17.818 km\u00B2",
-        "Revealed": false
+        "Comment": "17.818 km²"
       },
       {
         "Text": "Laos",
         "Correct": true,
-        "Comment": "236.800 km\u00B2",
-        "Revealed": false
+        "Comment": "236.800 km²"
       },
       {
         "Text": "Neuseeland",
         "Correct": true,
-        "Comment": "270.534 km\u00B2",
-        "Revealed": false
+        "Comment": "270.534 km²"
       },
       {
-        "Text": "\u00D6sterreich",
+        "Text": "Österreich",
         "Correct": true,
-        "Comment": "83.858 km\u00B2",
-        "Revealed": false
+        "Comment": "83.858 km²"
       },
       {
         "Text": "Polen",
         "Correct": true,
-        "Comment": "312.685 km\u00B2",
-        "Revealed": false
+        "Comment": "312.685 km²"
       },
       {
         "Text": "Senegal",
         "Correct": true,
-        "Comment": "196.722 km\u00B2",
-        "Revealed": false
+        "Comment": "196.722 km²"
       },
       {
         "Text": "Singapur",
         "Correct": true,
-        "Comment": "648 km\u00B2",
-        "Revealed": false
+        "Comment": "648 km²"
       },
       {
         "Text": "Tunesien",
         "Correct": true,
-        "Comment": "163.610 km\u00B2",
-        "Revealed": false
+        "Comment": "163.610 km²"
       },
       {
         "Text": "Uruguay",
         "Correct": true,
-        "Comment": "175.016 km\u00B2",
-        "Revealed": false
+        "Comment": "175.016 km²"
       },
       {
         "Text": "Venezuela",
         "Correct": false,
-        "Comment": "912.050 km\u00B2",
-        "Revealed": false
+        "Comment": "912.050 km²"
       }
     ]
   },
@@ -1942,100 +1638,84 @@
     "Selected": false,
     "Answers": [
       {
-        "Text": "1. Germanische V\u00F6lkerwanderung",
+        "Text": "1. Germanische Völkerwanderung",
         "Correct": true,
-        "Comment": "um 150",
-        "Revealed": false
+        "Comment": "um 150"
       },
       {
-        "Text": "2. Germanische V\u00F6lkerwanderung",
+        "Text": "2. Germanische Völkerwanderung",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Aufruf zum zweiten Kreuzzug",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bau der chinesischen Mauer",
         "Correct": true,
-        "Comment": "um 580",
-        "Revealed": false
+        "Comment": "um 580"
       },
       {
-        "Text": "Entstehung  \u00E4lteste deut. Schulordnung",
+        "Text": "Entstehung  älteste deut. Schulordnung",
         "Correct": true,
-        "Comment": "731 in Fritzlar",
-        "Revealed": false
+        "Comment": "731 in Fritzlar"
       },
       {
-        "Text": "Entstehung \u00E4lt. dt. Kirchenlied",
+        "Text": "Entstehung ält. dt. Kirchenlied",
         "Correct": true,
-        "Comment": "885 (\u0022Petruslied\u0022)",
-        "Revealed": false
+        "Comment": "885 (\"Petruslied\")"
       },
       {
         "Text": "erste Orgel in Frankreich",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Fertigstellung der Wartburg",
         "Correct": false,
-        "Comment": "um 1260",
-        "Revealed": false
+        "Comment": "um 1260"
       },
       {
-        "Text": "Kaiserkr\u00F6nung Barbarossas",
+        "Text": "Kaiserkrönung Barbarossas",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "K\u00F6ln wird Stadt",
+        "Text": "Köln wird Stadt",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Kr\u00F6nung Karls des Gro\u00DFen",
+        "Text": "Krönung Karls des Großen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Papst Leo III.",
         "Correct": true,
-        "Comment": "um 800",
-        "Revealed": false
+        "Comment": "um 800"
       },
       {
-        "Text": "Richard L\u00F6wenherz wird K\u00F6nig",
+        "Text": "Richard Löwenherz wird König",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tod von Harun al Raschid",
         "Correct": true,
-        "Comment": "809 (s. \u00221001 Nacht\u0022)",
-        "Revealed": false
+        "Comment": "809 (s. \"1001 Nacht\")"
       },
       {
         "Text": "Tod von Kaiser Otto III.",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Vasco da Gama",
         "Correct": false,
-        "Comment": "um 1500 (port. Seefahrer)",
-        "Revealed": false
+        "Comment": "um 1500 (port. Seefahrer)"
       }
     ]
   },
@@ -2044,406 +1724,342 @@
     "Selected": false,
     "Answers": [
       {
-        "Text": "Ausb\u00FCrgerung von Nina Hagen/Wolf Biermann",
+        "Text": "Ausbürgerung von Nina Hagen/Wolf Biermann",
         "Correct": true,
-        "Comment": "in 1976",
-        "Revealed": false
+        "Comment": "in 1976"
       },
       {
-        "Text": "Beginn der \u0022Dallas\u0022-Ausstrahlungen",
+        "Text": "Beginn der \"Dallas\"-Ausstrahlungen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Entf\u00FChrung der Kronzucker-Kinder",
+        "Text": "Entführung der Kronzucker-Kinder",
         "Correct": true,
-        "Comment": "in 1980",
-        "Revealed": false
+        "Comment": "in 1980"
       },
       {
         "Text": "Erste Direktwahl zum Europa-Parlament",
         "Correct": true,
-        "Comment": "10.06.1979",
-        "Revealed": false
+        "Comment": "10.06.1979"
       },
       {
         "Text": "FC Bayern wird zum 7. Mal Deut. Meister",
         "Correct": false,
-        "Comment": "13.06.1981",
-        "Revealed": false
+        "Comment": "13.06.1981"
       },
       {
-        "Text": "Karl Carstens wird Bundespr\u00E4sident",
+        "Text": "Karl Carstens wird Bundespräsident",
         "Correct": true,
-        "Comment": "23.05.1979",
-        "Revealed": false
+        "Comment": "23.05.1979"
       },
       {
-        "Text": "kirchliches Lehrverbot f\u00FCr Theol. Hans K\u00FCng",
+        "Text": "kirchliches Lehrverbot für Theol. Hans Küng",
         "Correct": true,
-        "Comment": "18.12.1979",
-        "Revealed": false
+        "Comment": "18.12.1979"
       },
       {
         "Text": "Ludwig Erhard stirbt",
         "Correct": true,
-        "Comment": "15.12.1977",
-        "Revealed": false
+        "Comment": "15.12.1977"
       },
       {
-        "Text": "M. Bachmeier t\u00F6tet M\u00F6rder ihrer Tochter",
+        "Text": "M. Bachmeier tötet Mörder ihrer Tochter",
         "Correct": false,
-        "Comment": "06.03.1981",
-        "Revealed": false
+        "Comment": "06.03.1981"
       },
       {
-        "Text": "Produktion letzter \u0022K\u00E4fers\u0022 in BRD",
+        "Text": "Produktion letzter \"Käfers\" in BRD",
         "Correct": true,
-        "Comment": "19.01.1978",
-        "Revealed": false
+        "Comment": "19.01.1978"
       },
       {
-        "Text": "R\u00FCcktritt von Bundeskanzler Willy Brandt",
+        "Text": "Rücktritt von Bundeskanzler Willy Brandt",
         "Correct": true,
-        "Comment": "07.05.1974",
-        "Revealed": false
+        "Comment": "07.05.1974"
       },
       {
-        "Text": "Sch\u00FCsse auf Rudi Dutschke",
+        "Text": "Schüsse auf Rudi Dutschke",
         "Correct": false,
-        "Comment": "11.04.1969",
-        "Revealed": false
+        "Comment": "11.04.1969"
       },
       {
         "Text": "Tod von Walter Ulbricht",
         "Correct": true,
-        "Comment": "01.08.1973",
-        "Revealed": false
+        "Comment": "01.08.1973"
       },
       {
         "Text": "Verhaftung von Baader und Meinhof",
         "Correct": true,
-        "Comment": "2.\u002B15.6.72",
-        "Revealed": false
+        "Comment": "2.+15.6.72"
       },
       {
-        "Text": "Wahl Gustav Heinemanns zum Bundespr\u00E4sidenten",
+        "Text": "Wahl Gustav Heinemanns zum Bundespräsidenten",
         "Correct": false,
-        "Comment": "05.03.1969",
-        "Revealed": false
+        "Comment": "05.03.1969"
       },
       {
         "Text": "Zusammenbruch der Herstatt-Bank",
         "Correct": true,
-        "Comment": "26.06.1974",
-        "Revealed": false
+        "Comment": "26.06.1974"
       }
     ]
   },
   {
-    "Text": "Welche Fl\u00FCsse flie\u00DFen in Deutschland?",
+    "Text": "Welche Flüsse fließen in Deutschland?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Aa",
         "Correct": true,
-        "Comment": "NRW",
-        "Revealed": false
+        "Comment": "NRW"
       },
       {
         "Text": "Aller",
         "Correct": true,
-        "Comment": "Niedersachsen",
-        "Revealed": false
+        "Comment": "Niedersachsen"
       },
       {
         "Text": "Drau",
         "Correct": false,
-        "Comment": "\u00D6sterr./Jugoslawien",
-        "Revealed": false
+        "Comment": "Österr./Jugoslawien"
       },
       {
         "Text": "Eider",
         "Correct": true,
-        "Comment": "Schleswig-Holstein",
-        "Revealed": false
+        "Comment": "Schleswig-Holstein"
       },
       {
         "Text": "Etsch",
         "Correct": false,
-        "Comment": "Italien",
-        "Revealed": false
+        "Comment": "Italien"
       },
       {
         "Text": "Ill",
         "Correct": false,
-        "Comment": "\u00D6sterreich",
-        "Revealed": false
+        "Comment": "Österreich"
       },
       {
         "Text": "Iller",
         "Correct": true,
-        "Comment": "Bayern",
-        "Revealed": false
+        "Comment": "Bayern"
       },
       {
         "Text": "Inn",
         "Correct": true,
-        "Comment": "Bayern",
-        "Revealed": false
+        "Comment": "Bayern"
       },
       {
         "Text": "Kocher",
         "Correct": true,
-        "Comment": "Baden-W\u00FCrttemberg",
-        "Revealed": false
+        "Comment": "Baden-Württemberg"
       },
       {
         "Text": "Meurthe",
         "Correct": false,
-        "Comment": "Frankreich",
-        "Revealed": false
+        "Comment": "Frankreich"
       },
       {
         "Text": "Nidda",
         "Correct": true,
-        "Comment": "Hessen",
-        "Revealed": false
+        "Comment": "Hessen"
       },
       {
         "Text": "Platte",
         "Correct": false,
-        "Comment": "USA",
-        "Revealed": false
+        "Comment": "USA"
       },
       {
         "Text": "Po",
         "Correct": false,
-        "Comment": "Italien",
-        "Revealed": false
+        "Comment": "Italien"
       },
       {
         "Text": "Olt",
         "Correct": false,
-        "Comment": "Rum\u00E4nien",
-        "Revealed": false
+        "Comment": "Rumänien"
       },
       {
         "Text": "Treene",
         "Correct": true,
-        "Comment": "Schleswig-Holstein",
-        "Revealed": false
+        "Comment": "Schleswig-Holstein"
       },
       {
         "Text": "Warnow",
         "Correct": true,
-        "Comment": "Meckl.-Vorpommern",
-        "Revealed": false
+        "Comment": "Meckl.-Vorpommern"
       }
     ]
   },
   {
-    "Text": "Welche Fl\u00FCsse flie\u00DFen in Europa?",
+    "Text": "Welche Flüsse fließen in Europa?",
     "Selected": true,
     "Answers": [
       {
         "Text": "Basento",
         "Correct": true,
-        "Comment": "S\u00FCditalien",
-        "Revealed": false
+        "Comment": "Süditalien"
       },
       {
         "Text": "Ebro",
         "Correct": true,
-        "Comment": "Spanien",
-        "Revealed": false
+        "Comment": "Spanien"
       },
       {
         "Text": "Enz",
         "Correct": true,
-        "Comment": "Deutschland",
-        "Revealed": false
+        "Comment": "Deutschland"
       },
       {
         "Text": "Flinders",
         "Correct": false,
-        "Comment": "Australien",
-        "Revealed": false
+        "Comment": "Australien"
       },
       {
         "Text": "Iijoki",
         "Correct": true,
-        "Comment": "Finnland",
-        "Revealed": false
+        "Comment": "Finnland"
       },
       {
         "Text": "Lena",
         "Correct": false,
-        "Comment": "Sibirien (Asien)",
-        "Revealed": false
+        "Comment": "Sibirien (Asien)"
       },
       {
         "Text": "Naab",
         "Correct": true,
-        "Comment": "Bayern",
-        "Revealed": false
+        "Comment": "Bayern"
       },
       {
         "Text": "Oranje",
         "Correct": false,
-        "Comment": "S\u00FCdafrika",
-        "Revealed": false
+        "Comment": "Südafrika"
       },
       {
         "Text": "Parana",
         "Correct": false,
-        "Comment": "Brasilien",
-        "Revealed": false
+        "Comment": "Brasilien"
       },
       {
         "Text": "Pruth",
         "Correct": true,
-        "Comment": "Ukraine",
-        "Revealed": false
+        "Comment": "Ukraine"
       },
       {
         "Text": "Reno",
         "Correct": true,
-        "Comment": "Italien",
-        "Revealed": false
+        "Comment": "Italien"
       },
       {
         "Text": "San",
         "Correct": true,
-        "Comment": "Polen",
-        "Revealed": false
+        "Comment": "Polen"
       },
       {
         "Text": "Son",
         "Correct": false,
-        "Comment": "Indien",
-        "Revealed": false
+        "Comment": "Indien"
       },
       {
         "Text": "St.-Lorenz-Strom",
         "Correct": false,
-        "Comment": "USA/Kanada",
-        "Revealed": false
+        "Comment": "USA/Kanada"
       },
       {
         "Text": "Tejo",
         "Correct": true,
-        "Comment": "Portugal",
-        "Revealed": false
+        "Comment": "Portugal"
       },
       {
         "Text": "Yukon",
         "Correct": false,
-        "Comment": "Alaska",
-        "Revealed": false
+        "Comment": "Alaska"
       }
     ]
   },
   {
-    "Text": "Welche L\u00E4nder waren bei der Fu\u00DFball-WM 1998 dabei?",
+    "Text": "Welche Länder waren bei der Fußball-WM 1998 dabei?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Argentinien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Belgien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bulgarien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Chile",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Indien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Iran",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kamerun",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kroatien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Marokko",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mexiko",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nigeria",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Norwegen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Portugal",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schweden",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ukraine",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ungarn",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -2454,710 +2070,598 @@
       {
         "Text": "Abschnitt 40",
         "Correct": true,
-        "Comment": "RTL",
-        "Revealed": false
+        "Comment": "RTL"
       },
       {
-        "Text": "Alarm f\u00FCr Cobra 11",
+        "Text": "Alarm für Cobra 11",
         "Correct": true,
-        "Comment": "RTL",
-        "Revealed": false
+        "Comment": "RTL"
       },
       {
-        "Text": "Bernd\u0027s Hexe",
+        "Text": "Bernd's Hexe",
         "Correct": true,
-        "Comment": "RTL",
-        "Revealed": false
+        "Comment": "RTL"
       },
       {
         "Text": "Der Bachelor",
         "Correct": true,
-        "Comment": "RTL",
-        "Revealed": false
+        "Comment": "RTL"
       },
       {
         "Text": "Die Nanny",
         "Correct": false,
-        "Comment": "VOX",
-        "Revealed": false
+        "Comment": "VOX"
       },
       {
-        "Text": "Gro\u00DFstadtrevier",
+        "Text": "Großstadtrevier",
         "Correct": false,
-        "Comment": "ARD",
-        "Revealed": false
+        "Comment": "ARD"
       },
       {
         "Text": "Hinter Gittern",
         "Correct": true,
-        "Comment": "RTL",
-        "Revealed": false
+        "Comment": "RTL"
       },
       {
         "Text": "K11 - Kommissare im Einsatz",
         "Correct": false,
-        "Comment": "SAT 1",
-        "Revealed": false
+        "Comment": "SAT 1"
       },
       {
         "Text": "Marienhof",
         "Correct": false,
-        "Comment": "ARD",
-        "Revealed": false
+        "Comment": "ARD"
       },
       {
         "Text": "Mein Leben und ich",
         "Correct": true,
-        "Comment": "RTL",
-        "Revealed": false
+        "Comment": "RTL"
       },
       {
         "Text": "Nikola",
         "Correct": true,
-        "Comment": "RTL",
-        "Revealed": false
+        "Comment": "RTL"
       },
       {
         "Text": "Rettungsflieger",
         "Correct": false,
-        "Comment": "ZDF",
-        "Revealed": false
+        "Comment": "ZDF"
       },
       {
         "Text": "Ritas Welt",
         "Correct": true,
-        "Comment": "RTL",
-        "Revealed": false
+        "Comment": "RTL"
       },
       {
         "Text": "Siska",
         "Correct": false,
-        "Comment": "ZDF",
-        "Revealed": false
+        "Comment": "ZDF"
       },
       {
-        "Text": "SK K\u00F6lsch",
+        "Text": "SK Kölsch",
         "Correct": false,
-        "Comment": "SAT 1",
-        "Revealed": false
+        "Comment": "SAT 1"
       },
       {
         "Text": "Unter uns",
         "Correct": true,
-        "Comment": "RTL",
-        "Revealed": false
+        "Comment": "RTL"
       }
     ]
   },
   {
-    "Text": "Welche Titel geh\u00F6ren zu Krimi-Serien?",
+    "Text": "Welche Titel gehören zu Krimi-Serien?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Alphateam",
         "Correct": false,
-        "Comment": "SAT1",
-        "Revealed": false
+        "Comment": "SAT1"
       },
       {
-        "Text": "Broti \u0026 Pacek",
+        "Text": "Broti & Pacek",
         "Correct": false,
-        "Comment": "SAT1",
-        "Revealed": false
+        "Comment": "SAT1"
       },
       {
-        "Text": "Bulle von T\u00F6lz",
+        "Text": "Bulle von Tölz",
         "Correct": true,
-        "Comment": "SAT1",
-        "Revealed": false
+        "Comment": "SAT1"
       },
       {
-        "Text": "Corneil \u0026 Bernie",
+        "Text": "Corneil & Bernie",
         "Correct": false,
-        "Comment": "KIKA",
-        "Revealed": false
+        "Comment": "KIKA"
       },
       {
-        "Text": "CSI - den T\u00E4tern auf der Spur",
+        "Text": "CSI - den Tätern auf der Spur",
         "Correct": true,
-        "Comment": "VOX",
-        "Revealed": false
+        "Comment": "VOX"
       },
       {
         "Text": "Dangerfield",
         "Correct": true,
-        "Comment": "RTL",
-        "Revealed": false
+        "Comment": "RTL"
       },
       {
         "Text": "Der Alte",
         "Correct": true,
-        "Comment": "ZDF",
-        "Revealed": false
+        "Comment": "ZDF"
       },
       {
         "Text": "Derrick",
         "Correct": true,
-        "Comment": "ZDF",
-        "Revealed": false
+        "Comment": "ZDF"
       },
       {
         "Text": "Diagnose Mord",
         "Correct": true,
-        "Comment": "Kabel 1",
-        "Revealed": false
+        "Comment": "Kabel 1"
       },
       {
         "Text": "Fastlane",
         "Correct": false,
-        "Comment": "SAT1",
-        "Revealed": false
+        "Comment": "SAT1"
       },
       {
         "Text": "Friends",
         "Correct": false,
-        "Comment": "PRO7",
-        "Revealed": false
+        "Comment": "PRO7"
       },
       {
         "Text": "Herz und Handschellen",
         "Correct": true,
-        "Comment": "SAT1",
-        "Revealed": false
+        "Comment": "SAT1"
       },
       {
         "Text": "King of Queens",
         "Correct": false,
-        "Comment": "RTL II",
-        "Revealed": false
+        "Comment": "RTL II"
       },
       {
         "Text": "Quincy",
         "Correct": true,
-        "Comment": "RTL",
-        "Revealed": false
+        "Comment": "RTL"
       },
       {
         "Text": "Tatort",
         "Correct": true,
-        "Comment": "ARD",
-        "Revealed": false
+        "Comment": "ARD"
       },
       {
         "Text": "Wolffs Revier",
         "Correct": true,
-        "Comment": "SAT1",
-        "Revealed": false
+        "Comment": "SAT1"
       }
     ]
   },
   {
-    "Text": "Welche St\u00E4dte liegen zwischen \u00C4quator und n\u00F6rdl. Wendekreis (23 Grad n.B.)?",
+    "Text": "Welche Städte liegen zwischen Äquator und nördl. Wendekreis (23 Grad n.B.)?",
     "Selected": true,
     "Answers": [
       {
         "Text": "Bangkok",
         "Correct": true,
-        "Comment": "Thailand (14 Grad n.B.)",
-        "Revealed": false
+        "Comment": "Thailand (14 Grad n.B.)"
       },
       {
         "Text": "Caracas",
         "Correct": true,
-        "Comment": "Venezuala (10 Grad n.B.)",
-        "Revealed": false
+        "Comment": "Venezuala (10 Grad n.B.)"
       },
       {
         "Text": "Havanna",
         "Correct": true,
-        "Comment": "Kuba (23 Grad n.B.)",
-        "Revealed": false
+        "Comment": "Kuba (23 Grad n.B.)"
       },
       {
         "Text": "Hongkong",
         "Correct": true,
-        "Comment": "China (22 Grad n.B.)",
-        "Revealed": false
+        "Comment": "China (22 Grad n.B.)"
       },
       {
         "Text": "Jakarta",
         "Correct": false,
-        "Comment": "Indonesien (6 Grad s.B.)",
-        "Revealed": false
+        "Comment": "Indonesien (6 Grad s.B.)"
       },
       {
         "Text": "Kalkutta",
         "Correct": true,
-        "Comment": "Indien (22 Grad n.B.)",
-        "Revealed": false
+        "Comment": "Indien (22 Grad n.B.)"
       },
       {
         "Text": "Karachi",
         "Correct": false,
-        "Comment": "Pakistan (25 Grad n.B.)",
-        "Revealed": false
+        "Comment": "Pakistan (25 Grad n.B.)"
       },
       {
         "Text": "Kinshasa",
         "Correct": false,
-        "Comment": "Zaire (5 Grad s.B.)",
-        "Revealed": false
+        "Comment": "Zaire (5 Grad s.B.)"
       },
       {
         "Text": "Miami",
         "Correct": false,
-        "Comment": "USA (24 Grad n.B.)",
-        "Revealed": false
+        "Comment": "USA (24 Grad n.B.)"
       },
       {
         "Text": "Monrovia",
         "Correct": true,
-        "Comment": "Liberia (7 Grad n.B.)",
-        "Revealed": false
+        "Comment": "Liberia (7 Grad n.B.)"
       },
       {
         "Text": "Nairobi",
         "Correct": false,
-        "Comment": "Kenia (2 Grad s.B.)",
-        "Revealed": false
+        "Comment": "Kenia (2 Grad s.B.)"
       },
       {
         "Text": "Panama",
         "Correct": true,
-        "Comment": "Panama (9 Grad n.B.)",
-        "Revealed": false
+        "Comment": "Panama (9 Grad n.B.)"
       },
       {
         "Text": "Quito",
         "Correct": false,
-        "Comment": "Ecuador (1 Grad s.B.)",
-        "Revealed": false
+        "Comment": "Ecuador (1 Grad s.B.)"
       },
       {
         "Text": "Riad",
         "Correct": false,
-        "Comment": "Saudi-Arabien (25 G.n.B.)",
-        "Revealed": false
+        "Comment": "Saudi-Arabien (25 G.n.B.)"
       },
       {
         "Text": "Singapur",
         "Correct": true,
-        "Comment": "Singapur (2 Grad n.B.)",
-        "Revealed": false
+        "Comment": "Singapur (2 Grad n.B.)"
       },
       {
         "Text": "Taipeh",
         "Correct": false,
-        "Comment": "Taiwan (25 Grad n.B.)",
-        "Revealed": false
+        "Comment": "Taiwan (25 Grad n.B.)"
       }
     ]
   },
   {
-    "Text": "Welche Fl\u00FCsse sind l\u00E4nger als der Yukon-River (3.185 km)?",
+    "Text": "Welche Flüsse sind länger als der Yukon-River (3.185 km)?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Amazonas",
         "Correct": true,
-        "Comment": "6.518 km",
-        "Revealed": false
+        "Comment": "6.518 km"
       },
       {
         "Text": "Dnjepr",
         "Correct": false,
-        "Comment": "2.200 km",
-        "Revealed": false
+        "Comment": "2.200 km"
       },
       {
         "Text": "Don",
         "Correct": false,
-        "Comment": "1.870 km",
-        "Revealed": false
+        "Comment": "1.870 km"
       },
       {
         "Text": "Donau",
         "Correct": false,
-        "Comment": "647 km",
-        "Revealed": false
+        "Comment": "647 km"
       },
       {
         "Text": "Elbe",
         "Correct": false,
-        "Comment": "700 km",
-        "Revealed": false
+        "Comment": "700 km"
       },
       {
         "Text": "Hwangho",
         "Correct": true,
-        "Comment": "4.845 km",
-        "Revealed": false
+        "Comment": "4.845 km"
       },
       {
         "Text": "Indus",
         "Correct": true,
-        "Comment": "3.200 km",
-        "Revealed": false
+        "Comment": "3.200 km"
       },
       {
         "Text": "Jangtsekiang",
         "Correct": true,
-        "Comment": "6.000 km",
-        "Revealed": false
+        "Comment": "6.000 km"
       },
       {
         "Text": "Kongo",
         "Correct": true,
-        "Comment": "4.374 km",
-        "Revealed": false
+        "Comment": "4.374 km"
       },
       {
         "Text": "Mekong",
         "Correct": true,
-        "Comment": "4.500 km",
-        "Revealed": false
+        "Comment": "4.500 km"
       },
       {
         "Text": "Nil",
         "Correct": true,
-        "Comment": "6.671 km",
-        "Revealed": false
+        "Comment": "6.671 km"
       },
       {
         "Text": "Oder",
         "Correct": false,
-        "Comment": "750 km",
-        "Revealed": false
+        "Comment": "750 km"
       },
       {
         "Text": "Orinoko",
         "Correct": false,
-        "Comment": "2.140 km",
-        "Revealed": false
+        "Comment": "2.140 km"
       },
       {
         "Text": "Rhein",
         "Correct": false,
-        "Comment": "1.320 km",
-        "Revealed": false
+        "Comment": "1.320 km"
       },
       {
         "Text": "Rio Grande",
         "Correct": false,
-        "Comment": "3.034 km",
-        "Revealed": false
+        "Comment": "3.034 km"
       },
       {
         "Text": "Wolga",
         "Correct": true,
-        "Comment": "3.530 km",
-        "Revealed": false
+        "Comment": "3.530 km"
       }
     ]
   },
   {
-    "Text": "Welche Alpenp\u00E4sse gehen teilweise \u00FCber 2.500 m \u00FC. d. M. hinaus?",
+    "Text": "Welche Alpenpässe gehen teilweise über 2.500 m ü. d. M. hinaus?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Albulapass (Tiefencastel-La Punt)",
         "Correct": false,
-        "Comment": "2.312 m",
-        "Revealed": false
+        "Comment": "2.312 m"
       },
       {
         "Text": "Berninapass (Pontresina-Tirano)",
         "Correct": false,
-        "Comment": "2.382 m",
-        "Revealed": false
+        "Comment": "2.382 m"
       },
       {
         "Text": "Col de la Bonette (Jausiers-Nizza)",
         "Correct": true,
-        "Comment": "2.802 m",
-        "Revealed": false
+        "Comment": "2.802 m"
       },
       {
-        "Text": "Col de l\u0027Iseran (Seez-Bonneval-sur-Arc)",
+        "Text": "Col de l'Iseran (Seez-Bonneval-sur-Arc)",
         "Correct": true,
-        "Comment": "2.770 m",
-        "Revealed": false
+        "Comment": "2.770 m"
       },
       {
         "Text": "Col du Galibier (Arctal-Briancon)",
         "Correct": true,
-        "Comment": "2.646 m",
-        "Revealed": false
+        "Comment": "2.646 m"
       },
       {
-        "Text": "Fl\u00FCelapass (Davos-Susch)",
+        "Text": "Flüelapass (Davos-Susch)",
         "Correct": false,
-        "Comment": "2.383 m",
-        "Revealed": false
+        "Comment": "2.383 m"
       },
       {
         "Text": "Furka (Gletsch-Hospental)",
         "Correct": false,
-        "Comment": "2.431 m",
-        "Revealed": false
+        "Comment": "2.431 m"
       },
       {
-        "Text": "Gro\u00DFer St. Bernhard (Martigny-Aosta)",
+        "Text": "Großer St. Bernhard (Martigny-Aosta)",
         "Correct": false,
-        "Comment": "2.469 m",
-        "Revealed": false
+        "Comment": "2.469 m"
       },
       {
-        "Text": "Gro\u00DFglockner-Hochalpenstrasse (Zell a. S.-Lienz)",
+        "Text": "Großglockner-Hochalpenstrasse (Zell a. S.-Lienz)",
         "Correct": true,
-        "Comment": "2.505 m",
-        "Revealed": false
+        "Comment": "2.505 m"
       },
       {
         "Text": "Julier (Tiefencastel-Silvaplana)",
         "Correct": false,
-        "Comment": "2.284 m",
-        "Revealed": false
+        "Comment": "2.284 m"
       },
       {
         "Text": "Monte Schlacko (Wedau)",
         "Correct": false,
-        "Comment": "63 m",
-        "Revealed": false
+        "Comment": "63 m"
       },
       {
         "Text": "Nufenenpass (Ulrichen-Airolo)",
         "Correct": false,
-        "Comment": "2.478 m",
-        "Revealed": false
+        "Comment": "2.478 m"
       },
       {
         "Text": "Stilfser Joch (Prad-Bormio)",
         "Correct": true,
-        "Comment": "2.757 m",
-        "Revealed": false
+        "Comment": "2.757 m"
       },
       {
         "Text": "Susten (Innertkirchen-Wassen)",
         "Correct": false,
-        "Comment": "2.224 m",
-        "Revealed": false
+        "Comment": "2.224 m"
       },
       {
         "Text": "Timmelsjoch (Oetz-Meran)",
         "Correct": false,
-        "Comment": "2.497 m",
-        "Revealed": false
+        "Comment": "2.497 m"
       },
       {
         "Text": "Umbrailpass (Santa Maria i. M.-Cantoniera)",
         "Correct": true,
-        "Comment": "2.501 m",
-        "Revealed": false
+        "Comment": "2.501 m"
       }
     ]
   },
   {
-    "Text": "Welcher Baum kann in Deutschland ausgewachsen gr\u00F6\u00DFer als 26 m werden?",
+    "Text": "Welcher Baum kann in Deutschland ausgewachsen größer als 26 m werden?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Bergahorn",
         "Correct": false,
-        "Comment": "25 m",
-        "Revealed": false
+        "Comment": "25 m"
       },
       {
         "Text": "Birke",
         "Correct": true,
-        "Comment": "28 m",
-        "Revealed": false
+        "Comment": "28 m"
       },
       {
         "Text": "Douglasie",
         "Correct": true,
-        "Comment": "58 m",
-        "Revealed": false
+        "Comment": "58 m"
       },
       {
         "Text": "Eiche",
         "Correct": true,
-        "Comment": "40 m",
-        "Revealed": false
+        "Comment": "40 m"
       },
       {
         "Text": "Esche",
         "Correct": true,
-        "Comment": "40 m",
-        "Revealed": false
+        "Comment": "40 m"
       },
       {
         "Text": "Fichte",
         "Correct": true,
-        "Comment": "60 m",
-        "Revealed": false
+        "Comment": "60 m"
       },
       {
         "Text": "Kiefer",
         "Correct": true,
-        "Comment": "48 m",
-        "Revealed": false
+        "Comment": "48 m"
       },
       {
-        "Text": "L\u00E4rche",
+        "Text": "Lärche",
         "Correct": true,
-        "Comment": "54 m",
-        "Revealed": false
+        "Comment": "54 m"
       },
       {
         "Text": "Magnolie",
         "Correct": false,
-        "Comment": "10 m",
-        "Revealed": false
+        "Comment": "10 m"
       },
       {
         "Text": "Rotbuche",
         "Correct": true,
-        "Comment": "30 m",
-        "Revealed": false
+        "Comment": "30 m"
       },
       {
         "Text": "Schwarzerle",
         "Correct": false,
-        "Comment": "25 m",
-        "Revealed": false
+        "Comment": "25 m"
       },
       {
         "Text": "Schwarzpappel",
         "Correct": true,
-        "Comment": "30 m",
-        "Revealed": false
+        "Comment": "30 m"
       },
       {
         "Text": "Spitzahorn",
         "Correct": false,
-        "Comment": "25 m",
-        "Revealed": false
+        "Comment": "25 m"
       },
       {
         "Text": "Tanne",
         "Correct": true,
-        "Comment": "50 m",
-        "Revealed": false
+        "Comment": "50 m"
       },
       {
         "Text": "Ulme",
         "Correct": true,
-        "Comment": "30 m",
-        "Revealed": false
+        "Comment": "30 m"
       },
       {
-        "Text": "Wei\u00DFbuche",
+        "Text": "Weißbuche",
         "Correct": false,
-        "Comment": "25 m",
-        "Revealed": false
+        "Comment": "25 m"
       }
     ]
   },
   {
-    "Text": "Welches Tier ist l\u00E4nger tr\u00E4chtig als ein Wildschwein (ca. 135 Tage)?",
+    "Text": "Welches Tier ist länger trächtig als ein Wildschwein (ca. 135 Tage)?",
     "Selected": true,
     "Answers": [
       {
         "Text": "Blauwal",
         "Correct": true,
-        "Comment": "320-365 Tage",
-        "Revealed": false
+        "Comment": "320-365 Tage"
       },
       {
-        "Text": "Eis-/Braunb\u00E4r",
+        "Text": "Eis-/Braunbär",
         "Correct": true,
-        "Comment": "240 Tage",
-        "Revealed": false
+        "Comment": "240 Tage"
       },
       {
         "Text": "Europ. Feldhase",
         "Correct": false,
-        "Comment": "42-44 Tage",
-        "Revealed": false
+        "Comment": "42-44 Tage"
       },
       {
-        "Text": "G\u00E4mse",
+        "Text": "Gämse",
         "Correct": true,
-        "Comment": "147-190 Tage",
-        "Revealed": false
+        "Comment": "147-190 Tage"
       },
       {
         "Text": "Gorilla",
         "Correct": true,
-        "Comment": "251-289 Tage",
-        "Revealed": false
+        "Comment": "251-289 Tage"
       },
       {
         "Text": "Hausmaus",
         "Correct": false,
-        "Comment": "21-24 Tage",
-        "Revealed": false
+        "Comment": "21-24 Tage"
       },
       {
         "Text": "Indischer Elefant",
         "Correct": true,
-        "Comment": "623-660 Tage",
-        "Revealed": false
+        "Comment": "623-660 Tage"
       },
       {
-        "Text": "L\u00F6we",
+        "Text": "Löwe",
         "Correct": false,
-        "Comment": "108 Tage",
-        "Revealed": false
+        "Comment": "108 Tage"
       },
       {
         "Text": "Panzernashorn",
         "Correct": true,
-        "Comment": "480 Tage",
-        "Revealed": false
+        "Comment": "480 Tage"
       },
       {
-        "Text": "Riesenk\u00E4nguru",
+        "Text": "Riesenkänguru",
         "Correct": false,
-        "Comment": "33 Tage",
-        "Revealed": false
+        "Comment": "33 Tage"
       },
       {
         "Text": "Rotfuchs",
         "Correct": false,
-        "Comment": "52-55 Tage",
-        "Revealed": false
+        "Comment": "52-55 Tage"
       },
       {
         "Text": "Rothirsch",
         "Correct": true,
-        "Comment": "280 Tage",
-        "Revealed": false
+        "Comment": "280 Tage"
       },
       {
         "Text": "Sattelrobbe",
         "Correct": true,
-        "Comment": "355 Tage",
-        "Revealed": false
+        "Comment": "355 Tage"
       },
       {
         "Text": "Schimpanse",
         "Correct": true,
-        "Comment": "216-261 Tage",
-        "Revealed": false
+        "Comment": "216-261 Tage"
       },
       {
         "Text": "Tiger",
         "Correct": false,
-        "Comment": "103-110 Tage",
-        "Revealed": false
+        "Comment": "103-110 Tage"
       },
       {
         "Text": "Wildkaninchen",
         "Correct": false,
-        "Comment": "28-31 Tage",
-        "Revealed": false
+        "Comment": "28-31 Tage"
       }
     ]
   },
@@ -3166,100 +2670,84 @@
     "Selected": false,
     "Answers": [
       {
-        "Text": "Braunb\u00E4r",
+        "Text": "Braunbär",
         "Correct": false,
-        "Comment": "280 kg",
-        "Revealed": false
+        "Comment": "280 kg"
       },
       {
         "Text": "Forelle",
         "Correct": true,
-        "Comment": "bis 5 kg",
-        "Revealed": false
+        "Comment": "bis 5 kg"
       },
       {
         "Text": "Karpfen",
         "Correct": true,
-        "Comment": "bis 25 kg",
-        "Revealed": false
+        "Comment": "bis 25 kg"
       },
       {
-        "Text": "Landschildkr\u00F6te",
+        "Text": "Landschildkröte",
         "Correct": true,
-        "Comment": "2,5 kg",
-        "Revealed": false
+        "Comment": "2,5 kg"
       },
       {
-        "Text": "Lederschildkr\u00F6te",
+        "Text": "Lederschildkröte",
         "Correct": false,
-        "Comment": "bis 600 kg",
-        "Revealed": false
+        "Comment": "bis 600 kg"
       },
       {
-        "Text": "L\u00F6we",
+        "Text": "Löwe",
         "Correct": true,
-        "Comment": "130 kg",
-        "Revealed": false
+        "Comment": "130 kg"
       },
       {
-        "Text": "m\u00E4nnl. Seeelefant",
+        "Text": "männl. Seeelefant",
         "Correct": false,
-        "Comment": "4000 kg",
-        "Revealed": false
+        "Comment": "4000 kg"
       },
       {
         "Text": "Nashorn",
         "Correct": false,
-        "Comment": "2000 kg",
-        "Revealed": false
+        "Comment": "2000 kg"
       },
       {
         "Text": "Pferd",
         "Correct": false,
-        "Comment": "bis 1000 kg",
-        "Revealed": false
+        "Comment": "bis 1000 kg"
       },
       {
         "Text": "Reh",
         "Correct": true,
-        "Comment": "25 kg",
-        "Revealed": false
+        "Comment": "25 kg"
       },
       {
-        "Text": "Strau\u00DF",
+        "Text": "Strauß",
         "Correct": true,
-        "Comment": "90 kg",
-        "Revealed": false
+        "Comment": "90 kg"
       },
       {
         "Text": "Teufelsrochen",
         "Correct": false,
-        "Comment": "bis 600 kg",
-        "Revealed": false
+        "Comment": "bis 600 kg"
       },
       {
         "Text": "Thunfisch",
         "Correct": false,
-        "Comment": "bis 500 kg",
-        "Revealed": false
+        "Comment": "bis 500 kg"
       },
       {
         "Text": "weibl. Seeelefant",
         "Correct": false,
-        "Comment": "1500 kg",
-        "Revealed": false
+        "Comment": "1500 kg"
       },
       {
         "Text": "Wildschwein",
         "Correct": true,
-        "Comment": "200 kg",
-        "Revealed": false
+        "Comment": "200 kg"
       },
       {
         "Text": "Wolf",
         "Correct": true,
-        "Comment": "bis 50 kg",
-        "Revealed": false
+        "Comment": "bis 50 kg"
       }
     ]
   },
@@ -3270,98 +2758,82 @@
       {
         "Text": "Amsel",
         "Correct": true,
-        "Comment": "20 Jahre",
-        "Revealed": false
+        "Comment": "20 Jahre"
       },
       {
         "Text": "Auster",
         "Correct": false,
-        "Comment": "10 Jahre",
-        "Revealed": false
+        "Comment": "10 Jahre"
       },
       {
         "Text": "Biber",
         "Correct": true,
-        "Comment": "15-25 Jahre",
-        "Revealed": false
+        "Comment": "15-25 Jahre"
       },
       {
         "Text": "Blindschleiche",
         "Correct": true,
-        "Comment": "30 Jahre",
-        "Revealed": false
+        "Comment": "30 Jahre"
       },
       {
-        "Text": "Eichh\u00F6rnchen",
+        "Text": "Eichhörnchen",
         "Correct": false,
-        "Comment": "8-12 Jahre",
-        "Revealed": false
+        "Comment": "8-12 Jahre"
       },
       {
         "Text": "Fuchs",
         "Correct": false,
-        "Comment": "10-12 Jahre",
-        "Revealed": false
+        "Comment": "10-12 Jahre"
       },
       {
         "Text": "Haushund",
         "Correct": true,
-        "Comment": "15-25 Jahre",
-        "Revealed": false
+        "Comment": "15-25 Jahre"
       },
       {
         "Text": "Hausschaf",
         "Correct": false,
-        "Comment": "15 Jahre",
-        "Revealed": false
+        "Comment": "15 Jahre"
       },
       {
         "Text": "Hering",
         "Correct": true,
-        "Comment": "18 Jahre",
-        "Revealed": false
+        "Comment": "18 Jahre"
       },
       {
         "Text": "Kanarienvogel",
         "Correct": true,
-        "Comment": "24 Jahre",
-        "Revealed": false
+        "Comment": "24 Jahre"
       },
       {
-        "Text": "Maik\u00E4fer",
+        "Text": "Maikäfer",
         "Correct": false,
-        "Comment": "3-4 Jahre",
-        "Revealed": false
+        "Comment": "3-4 Jahre"
       },
       {
         "Text": "Meerschweinchen",
         "Correct": false,
-        "Comment": "7 Jahre",
-        "Revealed": false
+        "Comment": "7 Jahre"
       },
       {
-        "Text": "M\u00F6we",
+        "Text": "Möwe",
         "Correct": true,
-        "Comment": "30-45 Jahre",
-        "Revealed": false
+        "Comment": "30-45 Jahre"
       },
       {
         "Text": "Regenwurm",
         "Correct": false,
-        "Comment": "8-12 Jahre",
-        "Revealed": false
+        "Comment": "8-12 Jahre"
       },
       {
         "Text": "Reh",
         "Correct": false,
-        "Comment": "10-12 Jahre",
-        "Revealed": false
+        "Comment": "10-12 Jahre"
       },
       {
         "Text": "Wellensittich",
         "Correct": false,
-        "Comment": "10-13 Jahre",
-        "Revealed": false
+        "Comment": "10-13 Jahre"
       }
     ]
   },
@@ -3372,98 +2844,82 @@
       {
         "Text": "Birkhuhn",
         "Correct": false,
-        "Comment": "35 g",
-        "Revealed": false
+        "Comment": "35 g"
       },
       {
         "Text": "Elster",
         "Correct": false,
-        "Comment": "10 g",
-        "Revealed": false
+        "Comment": "10 g"
       },
       {
         "Text": "Flamingo",
         "Correct": true,
-        "Comment": "160 g",
-        "Revealed": false
+        "Comment": "160 g"
       },
       {
-        "Text": "G\u00E4nsegeier",
+        "Text": "Gänsegeier",
         "Correct": true,
-        "Comment": "240 g",
-        "Revealed": false
+        "Comment": "240 g"
       },
       {
         "Text": "Habicht",
         "Correct": true,
-        "Comment": "60 g",
-        "Revealed": false
+        "Comment": "60 g"
       },
       {
         "Text": "Haushuhn",
         "Correct": true,
-        "Comment": "60 g",
-        "Revealed": false
+        "Comment": "60 g"
       },
       {
-        "Text": "H\u00F6ckerschwan",
+        "Text": "Höckerschwan",
         "Correct": true,
-        "Comment": "350 g",
-        "Revealed": false
+        "Comment": "350 g"
       },
       {
         "Text": "Kiwi",
         "Correct": true,
-        "Comment": "450 g",
-        "Revealed": false
+        "Comment": "450 g"
       },
       {
-        "Text": "Lachm\u00F6we",
+        "Text": "Lachmöwe",
         "Correct": false,
-        "Comment": "40 g",
-        "Revealed": false
+        "Comment": "40 g"
       },
       {
         "Text": "Pinguin",
         "Correct": true,
-        "Comment": "100 g",
-        "Revealed": false
+        "Comment": "100 g"
       },
       {
         "Text": "Rauchschwalbe",
         "Correct": false,
-        "Comment": "1,7 g",
-        "Revealed": false
+        "Comment": "1,7 g"
       },
       {
-        "Text": "Saatkr\u00E4he",
+        "Text": "Saatkrähe",
         "Correct": false,
-        "Comment": "20 g",
-        "Revealed": false
+        "Comment": "20 g"
       },
       {
-        "Text": "Silberm\u00F6we",
+        "Text": "Silbermöwe",
         "Correct": true,
-        "Comment": "90 g",
-        "Revealed": false
+        "Comment": "90 g"
       },
       {
         "Text": "Stockente",
         "Correct": false,
-        "Comment": "50 g",
-        "Revealed": false
+        "Comment": "50 g"
       },
       {
         "Text": "Uhu",
         "Correct": true,
-        "Comment": "75 g",
-        "Revealed": false
+        "Comment": "75 g"
       },
       {
-        "Text": "Wei\u00DFer Storch",
+        "Text": "Weißer Storch",
         "Correct": true,
-        "Comment": "115 g",
-        "Revealed": false
+        "Comment": "115 g"
       }
     ]
   },
@@ -3474,404 +2930,340 @@
       {
         "Text": "Eintagsfliege",
         "Correct": false,
-        "Comment": "0,5 m/s",
-        "Revealed": false
+        "Comment": "0,5 m/s"
       },
       {
         "Text": "Erdhummel",
         "Correct": false,
-        "Comment": "0,8 m/s",
-        "Revealed": false
+        "Comment": "0,8 m/s"
       },
       {
         "Text": "Feldheuschrecke",
         "Correct": false,
-        "Comment": "0,5 m/s",
-        "Revealed": false
+        "Comment": "0,5 m/s"
       },
       {
-        "Text": "Fieberm\u00FCcke",
+        "Text": "Fiebermücke",
         "Correct": false,
-        "Comment": "0,9 m/s",
-        "Revealed": false
+        "Comment": "0,9 m/s"
       },
       {
         "Text": "Hirschbremse",
         "Correct": true,
-        "Comment": "11 m/s",
-        "Revealed": false
+        "Comment": "11 m/s"
       },
       {
-        "Text": "Hirschk\u00E4fer",
+        "Text": "Hirschkäfer",
         "Correct": false,
-        "Comment": "1,5 m/s",
-        "Revealed": false
+        "Comment": "1,5 m/s"
       },
       {
         "Text": "Honigbiene",
         "Correct": true,
-        "Comment": "3,7 m/s",
-        "Revealed": false
+        "Comment": "3,7 m/s"
       },
       {
         "Text": "Hornisse",
         "Correct": true,
-        "Comment": "6,2 m/s",
-        "Revealed": false
+        "Comment": "6,2 m/s"
       },
       {
-        "Text": "Kohlwei\u00DFling",
+        "Text": "Kohlweißling",
         "Correct": false,
-        "Comment": "2 m/s",
-        "Revealed": false
+        "Comment": "2 m/s"
       },
       {
         "Text": "Libelle",
         "Correct": true,
-        "Comment": "15 m/s",
-        "Revealed": false
+        "Comment": "15 m/s"
       },
       {
-        "Text": "Maik\u00E4fer",
+        "Text": "Maikäfer",
         "Correct": true,
-        "Comment": "3 m/s",
-        "Revealed": false
+        "Comment": "3 m/s"
       },
       {
         "Text": "Rinderbremse",
         "Correct": true,
-        "Comment": "14 m/s",
-        "Revealed": false
+        "Comment": "14 m/s"
       },
       {
-        "Text": "Schmei\u00DFfliege",
+        "Text": "Schmeißfliege",
         "Correct": true,
-        "Comment": "2,7 m/s",
-        "Revealed": false
+        "Comment": "2,7 m/s"
       },
       {
         "Text": "Stubenfliege",
         "Correct": false,
-        "Comment": "2 m/s",
-        "Revealed": false
+        "Comment": "2 m/s"
       },
       {
         "Text": "Wespe",
         "Correct": false,
-        "Comment": "1,8 m/s",
-        "Revealed": false
+        "Comment": "1,8 m/s"
       },
       {
-        "Text": "W\u00FCsten-heuschrecke",
+        "Text": "Wüsten-heuschrecke",
         "Correct": true,
-        "Comment": "4,4 m/s",
-        "Revealed": false
+        "Comment": "4,4 m/s"
       }
     ]
   },
   {
-    "Text": "Wo f\u00E4llt pro Jahr mehr Regen als in Peking (63 cm)?",
+    "Text": "Wo fällt pro Jahr mehr Regen als in Peking (63 cm)?",
     "Selected": true,
     "Answers": [
       {
         "Text": "Athen",
         "Correct": false,
-        "Comment": "40 cm",
-        "Revealed": false
+        "Comment": "40 cm"
       },
       {
         "Text": "Berlin",
         "Correct": false,
-        "Comment": "58 cm",
-        "Revealed": false
+        "Comment": "58 cm"
       },
       {
         "Text": "Buenos Aires",
         "Correct": true,
-        "Comment": "98 cm",
-        "Revealed": false
+        "Comment": "98 cm"
       },
       {
         "Text": "Delhi",
         "Correct": true,
-        "Comment": "77 cm",
-        "Revealed": false
+        "Comment": "77 cm"
       },
       {
         "Text": "Hamburg",
         "Correct": true,
-        "Comment": "74 cm",
-        "Revealed": false
+        "Comment": "74 cm"
       },
       {
         "Text": "Lissabon",
         "Correct": true,
-        "Comment": "71 cm",
-        "Revealed": false
+        "Comment": "71 cm"
       },
       {
         "Text": "London",
         "Correct": false,
-        "Comment": "59 cm",
-        "Revealed": false
+        "Comment": "59 cm"
       },
       {
         "Text": "Moskau",
         "Correct": false,
-        "Comment": "58 cm",
-        "Revealed": false
+        "Comment": "58 cm"
       },
       {
         "Text": "New York",
         "Correct": true,
-        "Comment": "108 cm",
-        "Revealed": false
+        "Comment": "108 cm"
       },
       {
         "Text": "Paris",
         "Correct": false,
-        "Comment": "62 cm",
-        "Revealed": false
+        "Comment": "62 cm"
       },
       {
         "Text": "Rio de Janeiro",
         "Correct": true,
-        "Comment": "114 cm",
-        "Revealed": false
+        "Comment": "114 cm"
       },
       {
         "Text": "Rom",
         "Correct": true,
-        "Comment": "76 cm",
-        "Revealed": false
+        "Comment": "76 cm"
       },
       {
         "Text": "San Francisco",
         "Correct": false,
-        "Comment": "52 cm",
-        "Revealed": false
+        "Comment": "52 cm"
       },
       {
         "Text": "Stockholm",
         "Correct": false,
-        "Comment": "55 cm",
-        "Revealed": false
+        "Comment": "55 cm"
       },
       {
         "Text": "Tokio",
         "Correct": true,
-        "Comment": "162 cm",
-        "Revealed": false
+        "Comment": "162 cm"
       },
       {
         "Text": "Wien",
         "Correct": true,
-        "Comment": "66 cm",
-        "Revealed": false
+        "Comment": "66 cm"
       }
     ]
   },
   {
-    "Text": "Welches technische Ger\u00E4t wurde vor 1752 (Blitzableiter) erfunden?",
+    "Text": "Welches technische Gerät wurde vor 1752 (Blitzableiter) erfunden?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Alkohol-thermometer",
         "Correct": true,
-        "Comment": "1730",
-        "Revealed": false
+        "Comment": "1730"
       },
       {
-        "Text": "Dampfkochtopf \u0026 Sicherheitsventil",
+        "Text": "Dampfkochtopf & Sicherheitsventil",
         "Correct": true,
-        "Comment": "1664",
-        "Revealed": false
+        "Comment": "1664"
       },
       {
         "Text": "Dampfschiff",
         "Correct": false,
-        "Comment": "1798",
-        "Revealed": false
+        "Comment": "1798"
       },
       {
         "Text": "elektrisches Relais",
         "Correct": false,
-        "Comment": "1834",
-        "Revealed": false
+        "Comment": "1834"
       },
       {
         "Text": "Elektromagnet",
         "Correct": false,
-        "Comment": "1825",
-        "Revealed": false
+        "Comment": "1825"
       },
       {
         "Text": "Gewindeschneide-maschine",
         "Correct": true,
-        "Comment": "1568",
-        "Revealed": false
+        "Comment": "1568"
       },
       {
-        "Text": "Hei\u00DFluftballon",
+        "Text": "Heißluftballon",
         "Correct": false,
-        "Comment": "1782",
-        "Revealed": false
+        "Comment": "1782"
       },
       {
-        "Text": "Hei\u00DFvulkanisation",
+        "Text": "Heißvulkanisation",
         "Correct": false,
-        "Comment": "1839",
-        "Revealed": false
+        "Comment": "1839"
       },
       {
         "Text": "hydraulische Presse",
         "Correct": false,
-        "Comment": "1795",
-        "Revealed": false
+        "Comment": "1795"
       },
       {
         "Text": "Kolbenluftpumpe",
         "Correct": true,
-        "Comment": "1650",
-        "Revealed": false
+        "Comment": "1650"
       },
       {
         "Text": "mechanischer Webstuhl",
         "Correct": false,
-        "Comment": "1785",
-        "Revealed": false
+        "Comment": "1785"
       },
       {
-        "Text": "N\u00E4hmaschine",
+        "Text": "Nähmaschine",
         "Correct": false,
-        "Comment": "1755",
-        "Revealed": false
+        "Comment": "1755"
       },
       {
         "Text": "Quecksilber-barometer",
         "Correct": true,
-        "Comment": "1643",
-        "Revealed": false
+        "Comment": "1643"
       },
       {
         "Text": "Quecksilber-thermometer",
         "Correct": true,
-        "Comment": "1718",
-        "Revealed": false
+        "Comment": "1718"
       },
       {
         "Text": "Rechenmaschine (Addit./Subtrakt.)",
         "Correct": true,
-        "Comment": "1642",
-        "Revealed": false
+        "Comment": "1642"
       },
       {
         "Text": "Rechenmaschine (Multipl./Division)",
         "Correct": true,
-        "Comment": "1671",
-        "Revealed": false
+        "Comment": "1671"
       }
     ]
   },
   {
-    "Text": "Welche Komponisten geh\u00F6ren zur Romantik (1820-1910)?",
+    "Text": "Welche Komponisten gehören zur Romantik (1820-1910)?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Albert Lortzing",
         "Correct": true,
-        "Comment": "1801-1851",
-        "Revealed": false
+        "Comment": "1801-1851"
       },
       {
         "Text": "Carl Maria von Weber",
         "Correct": true,
-        "Comment": "1786-1826",
-        "Revealed": false
+        "Comment": "1786-1826"
       },
       {
         "Text": "Carl Philipp Emanuel Bach",
         "Correct": false,
-        "Comment": "1714-1788",
-        "Revealed": false
+        "Comment": "1714-1788"
       },
       {
         "Text": "Felix Mendelssohn-Bartholdy",
         "Correct": true,
-        "Comment": "1809-1847",
-        "Revealed": false
+        "Comment": "1809-1847"
       },
       {
         "Text": "Franz Schubert",
         "Correct": true,
-        "Comment": "1797-1828",
-        "Revealed": false
+        "Comment": "1797-1828"
       },
       {
         "Text": "Franz von Liszt",
         "Correct": true,
-        "Comment": "1811-1886",
-        "Revealed": false
+        "Comment": "1811-1886"
       },
       {
         "Text": "Frederic Chopin",
         "Correct": true,
-        "Comment": "1810-1849",
-        "Revealed": false
+        "Comment": "1810-1849"
       },
       {
         "Text": "Gustav Mahler",
         "Correct": true,
-        "Comment": "1860-1911",
-        "Revealed": false
+        "Comment": "1860-1911"
       },
       {
         "Text": "Johannes Brahms",
         "Correct": true,
-        "Comment": "1833-1897",
-        "Revealed": false
+        "Comment": "1833-1897"
       },
       {
         "Text": "Joseph Haydn",
         "Correct": false,
-        "Comment": "1732-1809",
-        "Revealed": false
+        "Comment": "1732-1809"
       },
       {
         "Text": "Ludwig von Beethoven",
         "Correct": false,
-        "Comment": "1770-1827",
-        "Revealed": false
+        "Comment": "1770-1827"
       },
       {
         "Text": "Maurice Ravel",
         "Correct": false,
-        "Comment": "1875-1937",
-        "Revealed": false
+        "Comment": "1875-1937"
       },
       {
         "Text": "Richard Strauss",
         "Correct": true,
-        "Comment": "1864-1949",
-        "Revealed": false
+        "Comment": "1864-1949"
       },
       {
         "Text": "Richard Wagner",
         "Correct": true,
-        "Comment": "1813-1883",
-        "Revealed": false
+        "Comment": "1813-1883"
       },
       {
         "Text": "Robert Schumann",
         "Correct": true,
-        "Comment": "1810-1849",
-        "Revealed": false
+        "Comment": "1810-1849"
       },
       {
         "Text": "Wolfgang Amadeus Mozart",
         "Correct": false,
-        "Comment": "1756-1827",
-        "Revealed": false
+        "Comment": "1756-1827"
       }
     ]
   },
@@ -3882,98 +3274,82 @@
       {
         "Text": "Basic Instinct",
         "Correct": false,
-        "Comment": "352 Mio. $",
-        "Revealed": false
+        "Comment": "352 Mio. $"
       },
       {
         "Text": "Der mit dem Wolf tanzt",
         "Correct": false,
-        "Comment": "424 Mio. $",
-        "Revealed": false
+        "Comment": "424 Mio. $"
       },
       {
         "Text": "Der Soldat James Ryan",
         "Correct": false,
-        "Comment": "479 Mio. $",
-        "Revealed": false
+        "Comment": "479 Mio. $"
       },
       {
-        "Text": "Die R\u00FCckkehr der Jedi-Ritter",
+        "Text": "Die Rückkehr der Jedi-Ritter",
         "Correct": false,
-        "Comment": "470 Mio. $",
-        "Revealed": false
+        "Comment": "470 Mio. $"
       },
       {
         "Text": "Die vergessene Welt: Jurassic Park (Teil 2)",
         "Correct": true,
-        "Comment": "614 Mio. $",
-        "Revealed": false
+        "Comment": "614 Mio. $"
       },
       {
-        "Text": "E.T. - Der Au\u00DFerirdische",
+        "Text": "E.T. - Der Außerirdische",
         "Correct": true,
-        "Comment": "705 Mio. $",
-        "Revealed": false
+        "Comment": "705 Mio. $"
       },
       {
         "Text": "Indiana Jones und der letzte Kreuzzug",
         "Correct": false,
-        "Comment": "494 Mio. $",
-        "Revealed": false
+        "Comment": "494 Mio. $"
       },
       {
         "Text": "Jurassic Park",
         "Correct": true,
-        "Comment": "919 Mio. $",
-        "Revealed": false
+        "Comment": "919 Mio. $"
       },
       {
-        "Text": "K\u00F6nig der L\u00F6wen",
+        "Text": "König der Löwen",
         "Correct": true,
-        "Comment": "766 Mio. $",
-        "Revealed": false
+        "Comment": "766 Mio. $"
       },
       {
         "Text": "Men in Black",
         "Correct": true,
-        "Comment": "586 Mio. $",
-        "Revealed": false
+        "Comment": "586 Mio. $"
       },
       {
         "Text": "Mission Impossible II",
         "Correct": false,
-        "Comment": "521 Mio. $",
-        "Revealed": false
+        "Comment": "521 Mio. $"
       },
       {
         "Text": "Notting Hill",
         "Correct": false,
-        "Comment": "363 Mio. $",
-        "Revealed": false
+        "Comment": "363 Mio. $"
       },
       {
         "Text": "Star Wars Epis. 1 - Dunkle Bedrohung",
         "Correct": true,
-        "Comment": "923 Mio. $",
-        "Revealed": false
+        "Comment": "923 Mio. $"
       },
       {
         "Text": "The Matrix",
         "Correct": false,
-        "Comment": "456 Mio. $",
-        "Revealed": false
+        "Comment": "456 Mio. $"
       },
       {
         "Text": "The Sixt Sense",
         "Correct": true,
-        "Comment": "661 Mio. $",
-        "Revealed": false
+        "Comment": "661 Mio. $"
       },
       {
         "Text": "Titanic",
         "Correct": true,
-        "Comment": "1835 Mio. $",
-        "Revealed": false
+        "Comment": "1835 Mio. $"
       }
     ]
   },
@@ -3982,814 +3358,686 @@
     "Selected": false,
     "Answers": [
       {
-        "Text": "Asterix und Obelix gegen C\u00E4sar",
+        "Text": "Asterix und Obelix gegen Cäsar",
         "Correct": false,
-        "Comment": "3,55 Mio.",
-        "Revealed": false
+        "Comment": "3,55 Mio."
       },
       {
         "Text": "Das Geisterhaus",
         "Correct": false,
-        "Comment": "3,86 Mio.",
-        "Revealed": false
+        "Comment": "3,86 Mio."
       },
       {
         "Text": "Der bewegte Mann",
         "Correct": true,
-        "Comment": "6,57 Mio.",
-        "Revealed": false
+        "Comment": "6,57 Mio."
       },
       {
         "Text": "Der Name der Rose",
         "Correct": true,
-        "Comment": "5,89 Mio.",
-        "Revealed": false
+        "Comment": "5,89 Mio."
       },
       {
         "Text": "Die unendliche Geschichte II",
         "Correct": true,
-        "Comment": "4,79 Mio.",
-        "Revealed": false
+        "Comment": "4,79 Mio."
       },
       {
         "Text": "Ich und er",
         "Correct": false,
-        "Comment": "3,52 Mio.",
-        "Revealed": false
+        "Comment": "3,52 Mio."
       },
       {
-        "Text": "Knockin\u0027 on Heaven\u0027s Door",
+        "Text": "Knockin' on Heaven's Door",
         "Correct": false,
-        "Comment": "3,59 Mio.",
-        "Revealed": false
+        "Comment": "3,59 Mio."
       },
       {
-        "Text": "M\u00E4nner",
+        "Text": "Männer",
         "Correct": true,
-        "Comment": "5,21 Mio.",
-        "Revealed": false
+        "Comment": "5,21 Mio."
       },
       {
-        "Text": "M\u00E4nnerpension",
+        "Text": "Männerpension",
         "Correct": false,
-        "Comment": "3,32 Mio.",
-        "Revealed": false
+        "Comment": "3,32 Mio."
       },
       {
-        "Text": "\u00D6dipussi",
+        "Text": "Ödipussi",
         "Correct": true,
-        "Comment": "4,67 Mio.",
-        "Revealed": false
+        "Comment": "4,67 Mio."
       },
       {
-        "Text": "Otto - der Au\u00DFerfriesische",
+        "Text": "Otto - der Außerfriesische",
         "Correct": false,
-        "Comment": "3,59 Mio.",
-        "Revealed": false
+        "Comment": "3,59 Mio."
       },
       {
         "Text": "Otto - der Film",
         "Correct": true,
-        "Comment": "8,75 Mio.",
-        "Revealed": false
+        "Comment": "8,75 Mio."
       },
       {
         "Text": "Otto - der Liebesfilm",
         "Correct": false,
-        "Comment": "2,86 Mio.",
-        "Revealed": false
+        "Comment": "2,86 Mio."
       },
       {
         "Text": "Otto - der neue Film",
         "Correct": true,
-        "Comment": "6,45 Mio.",
-        "Revealed": false
+        "Comment": "6,45 Mio."
       },
       {
         "Text": "Werner - beinhart",
         "Correct": true,
-        "Comment": "4,90 Mio.",
-        "Revealed": false
+        "Comment": "4,90 Mio."
       },
       {
         "Text": "Werner - das muss kesseln!",
         "Correct": true,
-        "Comment": "4,95 Mio.",
-        "Revealed": false
+        "Comment": "4,95 Mio."
       }
     ]
   },
   {
-    "Text": "Wer war Oscarpreistr\u00E4ger \u0022Hauptdarsteller\u0022 1980-1999?",
+    "Text": "Wer war Oscarpreisträger \"Hauptdarsteller\" 1980-1999?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Brad Pitt",
         "Correct": false,
-        "Comment": "-------",
-        "Revealed": false
+        "Comment": "-------"
       },
       {
         "Text": "Daniel Day-Lewis",
         "Correct": true,
-        "Comment": "1989",
-        "Revealed": false
+        "Comment": "1989"
       },
       {
         "Text": "Gene Hackman",
         "Correct": false,
-        "Comment": "1971",
-        "Revealed": false
+        "Comment": "1971"
       },
       {
         "Text": "Jack Lemmon",
         "Correct": false,
-        "Comment": "1973",
-        "Revealed": false
+        "Comment": "1973"
       },
       {
         "Text": "Jack Nicholson",
         "Correct": true,
-        "Comment": "1997",
-        "Revealed": false
+        "Comment": "1997"
       },
       {
         "Text": "Jackie Chan",
         "Correct": false,
-        "Comment": "-------",
-        "Revealed": false
+        "Comment": "-------"
       },
       {
         "Text": "Kevin Spacey",
         "Correct": true,
-        "Comment": "1999",
-        "Revealed": false
+        "Comment": "1999"
       },
       {
         "Text": "Michael Douglas",
         "Correct": true,
-        "Comment": "1987",
-        "Revealed": false
+        "Comment": "1987"
       },
       {
         "Text": "Morgan Freeman",
         "Correct": false,
-        "Comment": "-------",
-        "Revealed": false
+        "Comment": "-------"
       },
       {
         "Text": "Nicolas Cage",
         "Correct": true,
-        "Comment": "1995",
-        "Revealed": false
+        "Comment": "1995"
       },
       {
         "Text": "Peter Finch",
         "Correct": false,
-        "Comment": "1976",
-        "Revealed": false
+        "Comment": "1976"
       },
       {
         "Text": "Richard Dreyfuss",
         "Correct": false,
-        "Comment": "1977",
-        "Revealed": false
+        "Comment": "1977"
       },
       {
         "Text": "Robert Duvall",
         "Correct": true,
-        "Comment": "1983",
-        "Revealed": false
+        "Comment": "1983"
       },
       {
         "Text": "Terence Hill",
         "Correct": false,
-        "Comment": "-------",
-        "Revealed": false
+        "Comment": "-------"
       },
       {
         "Text": "Tom Cruise",
         "Correct": false,
-        "Comment": "-------",
-        "Revealed": false
+        "Comment": "-------"
       },
       {
         "Text": "Tom Hanks",
         "Correct": true,
-        "Comment": "1993, 1994",
-        "Revealed": false
+        "Comment": "1993, 1994"
       }
     ]
   },
   {
-    "Text": "Wer war Oscarpreistr\u00E4gerin \u0022Hauptdarstellerin\u0022 1980-1999?",
+    "Text": "Wer war Oscarpreisträgerin \"Hauptdarstellerin\" 1980-1999?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Diane Keaton",
         "Correct": false,
-        "Comment": "1977",
-        "Revealed": false
+        "Comment": "1977"
       },
       {
         "Text": "Emma Thompson",
         "Correct": true,
-        "Comment": "1992",
-        "Revealed": false
+        "Comment": "1992"
       },
       {
         "Text": "Goldie Hawn",
         "Correct": false,
-        "Comment": "-------",
-        "Revealed": false
+        "Comment": "-------"
       },
       {
         "Text": "Helen Hunt",
         "Correct": true,
-        "Comment": "1997",
-        "Revealed": false
+        "Comment": "1997"
       },
       {
         "Text": "Hillary Swank",
         "Correct": true,
-        "Comment": "1999",
-        "Revealed": false
+        "Comment": "1999"
       },
       {
         "Text": "Isabella Rosselini",
         "Correct": false,
-        "Comment": "-------",
-        "Revealed": false
+        "Comment": "-------"
       },
       {
         "Text": "Jane Fonda",
         "Correct": false,
-        "Comment": "1971, 1978",
-        "Revealed": false
+        "Comment": "1971, 1978"
       },
       {
         "Text": "Jodie Foster",
         "Correct": true,
-        "Comment": "1988,1991",
-        "Revealed": false
+        "Comment": "1988,1991"
       },
       {
         "Text": "Julia Roberts",
         "Correct": false,
-        "Comment": "-------",
-        "Revealed": false
+        "Comment": "-------"
       },
       {
         "Text": "Katherine Hepburn",
         "Correct": true,
-        "Comment": "1967, 1968, 1981",
-        "Revealed": false
+        "Comment": "1967, 1968, 1981"
       },
       {
         "Text": "Liza Minelli",
         "Correct": false,
-        "Comment": "1972",
-        "Revealed": false
+        "Comment": "1972"
       },
       {
         "Text": "Meg Ryan",
         "Correct": false,
-        "Comment": "-------",
-        "Revealed": false
+        "Comment": "-------"
       },
       {
         "Text": "Meryl Streep",
         "Correct": true,
-        "Comment": "1982",
-        "Revealed": false
+        "Comment": "1982"
       },
       {
         "Text": "Reese Witherspoon",
         "Correct": false,
-        "Comment": "-------",
-        "Revealed": false
+        "Comment": "-------"
       },
       {
         "Text": "Sandra Bullock",
         "Correct": false,
-        "Comment": "-------",
-        "Revealed": false
+        "Comment": "-------"
       },
       {
         "Text": "Shirley MacLaine",
         "Correct": true,
-        "Comment": "1983",
-        "Revealed": false
+        "Comment": "1983"
       }
     ]
   },
   {
-    "Text": "Welche L\u00E4nder sind kleiner als 100.000 km\u00B2?",
+    "Text": "Welche Länder sind kleiner als 100.000 km²?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Belgien",
         "Correct": true,
-        "Comment": "30.519 km\u00B2",
-        "Revealed": false
+        "Comment": "30.519 km²"
       },
       {
         "Text": "Bulgarien",
         "Correct": false,
-        "Comment": "110.912 km\u00B2",
-        "Revealed": false
+        "Comment": "110.912 km²"
       },
       {
-        "Text": "D\u00E4nemark",
+        "Text": "Dänemark",
         "Correct": true,
-        "Comment": "43.094 km\u00B2",
-        "Revealed": false
+        "Comment": "43.094 km²"
       },
       {
         "Text": "Ecuador",
         "Correct": false,
-        "Comment": "283.561 km\u00B2",
-        "Revealed": false
+        "Comment": "283.561 km²"
       },
       {
         "Text": "Finnland",
         "Correct": false,
-        "Comment": "338.145 km\u00B2",
-        "Revealed": false
+        "Comment": "338.145 km²"
       },
       {
         "Text": "Gabun",
         "Correct": false,
-        "Comment": "267.667 km\u00B2",
-        "Revealed": false
+        "Comment": "267.667 km²"
       },
       {
         "Text": "Griechenland",
         "Correct": false,
-        "Comment": "131.957 km\u00B2",
-        "Revealed": false
+        "Comment": "131.957 km²"
       },
       {
-        "Text": "Gro\u00DFbritannien \u0026 Nordirland",
+        "Text": "Großbritannien & Nordirland",
         "Correct": false,
-        "Comment": "244.101 km\u00B2",
-        "Revealed": false
+        "Comment": "244.101 km²"
       },
       {
         "Text": "Irland",
         "Correct": true,
-        "Comment": "70.284 km\u00B2",
-        "Revealed": false
+        "Comment": "70.284 km²"
       },
       {
         "Text": "Island",
         "Correct": false,
-        "Comment": "103.000 km\u00B2",
-        "Revealed": false
+        "Comment": "103.000 km²"
       },
       {
         "Text": "Italien",
         "Correct": false,
-        "Comment": "301.341 km\u00B2",
-        "Revealed": false
+        "Comment": "301.341 km²"
       },
       {
         "Text": "Kroatien",
         "Correct": true,
-        "Comment": "56.538 km\u00B2",
-        "Revealed": false
+        "Comment": "56.538 km²"
       },
       {
         "Text": "Niederlande",
         "Correct": true,
-        "Comment": "41.526 km\u00B2",
-        "Revealed": false
+        "Comment": "41.526 km²"
       },
       {
         "Text": "Portugal",
         "Correct": true,
-        "Comment": "92.389 km\u00B2",
-        "Revealed": false
+        "Comment": "92.389 km²"
       },
       {
-        "Text": "Rum\u00E4nien",
+        "Text": "Rumänien",
         "Correct": false,
-        "Comment": "238.391 km\u00B2",
-        "Revealed": false
+        "Comment": "238.391 km²"
       },
       {
         "Text": "Ungarn",
         "Correct": true,
-        "Comment": "93.030 km\u00B2",
-        "Revealed": false
+        "Comment": "93.030 km²"
       }
     ]
   },
   {
-    "Text": "Welche L\u00E4nder haben im W\u00E4hrungsnamen \u0022Dollar\u0022?",
+    "Text": "Welche Länder haben im Währungsnamen \"Dollar\"?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Australien",
         "Correct": true,
-        "Comment": "austr. $",
-        "Revealed": false
+        "Comment": "austr. $"
       },
       {
         "Text": "Bahrein",
         "Correct": false,
-        "Comment": "Bahrein-Dinar",
-        "Revealed": false
+        "Comment": "Bahrein-Dinar"
       },
       {
         "Text": "Belize",
         "Correct": true,
-        "Comment": "Belize-$",
-        "Revealed": false
+        "Comment": "Belize-$"
       },
       {
         "Text": "Brunei",
         "Correct": true,
-        "Comment": "Brunei-$",
-        "Revealed": false
+        "Comment": "Brunei-$"
       },
       {
         "Text": "Ecuador",
         "Correct": true,
-        "Comment": "US-$",
-        "Revealed": false
+        "Comment": "US-$"
       },
       {
         "Text": "Gambia",
         "Correct": false,
-        "Comment": "Dalasi",
-        "Revealed": false
+        "Comment": "Dalasi"
       },
       {
         "Text": "Guyana",
         "Correct": true,
-        "Comment": "Guyana-$",
-        "Revealed": false
+        "Comment": "Guyana-$"
       },
       {
         "Text": "Kanada",
         "Correct": true,
-        "Comment": "kanad. $",
-        "Revealed": false
+        "Comment": "kanad. $"
       },
       {
         "Text": "Kenia",
         "Correct": false,
-        "Comment": "Kenia-Schilling",
-        "Revealed": false
+        "Comment": "Kenia-Schilling"
       },
       {
         "Text": "Kuwait",
         "Correct": false,
-        "Comment": "Kuwait-Dinar",
-        "Revealed": false
+        "Comment": "Kuwait-Dinar"
       },
       {
         "Text": "Namibia",
         "Correct": true,
-        "Comment": "Namibia-$",
-        "Revealed": false
+        "Comment": "Namibia-$"
       },
       {
         "Text": "Simbabwe",
         "Correct": true,
-        "Comment": "Simbabwe-$",
-        "Revealed": false
+        "Comment": "Simbabwe-$"
       },
       {
         "Text": "Singapur",
         "Correct": true,
-        "Comment": "Singapur-$",
-        "Revealed": false
+        "Comment": "Singapur-$"
       },
       {
-        "Text": "S\u00FCdafrika",
+        "Text": "Südafrika",
         "Correct": false,
-        "Comment": "Rand",
-        "Revealed": false
+        "Comment": "Rand"
       },
       {
         "Text": "Taiwan",
         "Correct": true,
-        "Comment": "Neuer Taiwan-$",
-        "Revealed": false
+        "Comment": "Neuer Taiwan-$"
       },
       {
         "Text": "Zentralafrikan. Republik",
         "Correct": false,
-        "Comment": "CFA-Franc",
-        "Revealed": false
+        "Comment": "CFA-Franc"
       }
     ]
   },
   {
-    "Text": "Welche Vereine spielen in der 1. Fu\u00DFball-Bundesliga?",
+    "Text": "Welche Vereine spielen in der 1. Fußball-Bundesliga?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Hamburger SV",
         "Correct": false,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
         "Text": "Union Berlin",
         "Correct": true,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
-        "Text": "1. FC N\u00FCrnberg",
+        "Text": "1. FC Nürnberg",
         "Correct": false,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
         "Text": "Werder Bremen",
         "Correct": true,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
         "Text": "Hannover 96",
         "Correct": false,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
         "Text": "FC Augsburg",
         "Correct": true,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
         "Text": "Karlsruher SC",
         "Correct": false,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
-        "Text": "1. FC K\u00F6ln",
+        "Text": "1. FC Köln",
         "Correct": false,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
         "Text": "Borussia Dortmund",
         "Correct": true,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
         "Text": "Arminia Bielefeld",
         "Correct": false,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
-        "Text": "Fortuna D\u00FCsseldorf",
+        "Text": "Fortuna Düsseldorf",
         "Correct": false,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
         "Text": "Bayer Leverkusen",
         "Correct": true,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
         "Text": "VfB Stuttgart",
         "Correct": true,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
         "Text": "VfL Bochum",
         "Correct": true,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
         "Text": "Rasenball Leipzig",
         "Correct": true,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       },
       {
         "Text": "Eintracht Frankfurt",
         "Correct": true,
-        "Comment": "Stand: Saison 2024/25",
-        "Revealed": false
+        "Comment": "Stand: Saison 2024/25"
       }
     ]
   },
   {
-    "Text": "Welche Berge geh\u00F6ren zu den Alpen?",
+    "Text": "Welche Berge gehören zu den Alpen?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Col du Gallibier",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Col du Tourmalet",
         "Correct": false,
-        "Comment": "Pyren\u00E4en",
-        "Revealed": false
+        "Comment": "Pyrenäen"
       },
       {
         "Text": "Dachstein",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Grand Ballon",
         "Correct": false,
-        "Comment": "Vogesen",
-        "Revealed": false
+        "Comment": "Vogesen"
       },
       {
         "Text": "Herzogenhorn",
         "Correct": false,
-        "Comment": "Schwarzwald",
-        "Revealed": false
+        "Comment": "Schwarzwald"
       },
       {
         "Text": "Jenner",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Marmorlata",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Matterhorn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Monte Rosa",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nebelhorn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ortler",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Piz Buin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "S\u00E4ntis",
+        "Text": "Säntis",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schneekoppe",
         "Correct": false,
-        "Comment": "Riesengebirge",
-        "Revealed": false
+        "Comment": "Riesengebirge"
       },
       {
         "Text": "Watzmann",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wildspitze",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welches sind bekannte Kriegsschaupl\u00E4tze aus dem 2.Weltkrieg?",
+    "Text": "Welches sind bekannte Kriegsschauplätze aus dem 2.Weltkrieg?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Ardennen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Arnheim",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Beresina",
         "Correct": false,
-        "Comment": "Napoleonischen Kriege",
-        "Revealed": false
+        "Comment": "Napoleonischen Kriege"
       },
       {
         "Text": "Dien Bien Phu",
         "Correct": false,
-        "Comment": "Vietnam-Krieg",
-        "Revealed": false
+        "Comment": "Vietnam-Krieg"
       },
       {
-        "Text": "D\u00FCnkirchen",
+        "Text": "Dünkirchen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "El Alamein",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Guadalcanal",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Midway",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Monte Cassino",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Narvik",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Navaronne",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Normandie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pearl Harbour",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Stalingrad",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tannenberg",
         "Correct": false,
-        "Comment": "1.Weltkrieg",
-        "Revealed": false
+        "Comment": "1.Weltkrieg"
       },
       {
         "Text": "Verdun",
         "Correct": false,
-        "Comment": "1. Weltkrieg",
-        "Revealed": false
+        "Comment": "1. Weltkrieg"
       }
     ]
   },
@@ -4800,98 +4048,82 @@
       {
         "Text": "Der Hauch des Todes",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Hexer",
         "Correct": false,
-        "Comment": "Edgar Wallace",
-        "Revealed": false
+        "Comment": "Edgar Wallace"
       },
       {
         "Text": "Der Morgen stirbt nie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Der Spion der aus der K\u00E4lte kam",
+        "Text": "Der Spion der aus der Kälte kam",
         "Correct": false,
-        "Comment": "Simmel",
-        "Revealed": false
+        "Comment": "Simmel"
       },
       {
         "Text": "Der Spion der mich liebte",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der unsichtbare Dritte",
         "Correct": false,
-        "Comment": "Hitchcock",
-        "Revealed": false
+        "Comment": "Hitchcock"
       },
       {
         "Text": "Diamantenfieber",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die Welt ist nicht genug",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Feuerball",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "French Connection",
         "Correct": false,
-        "Comment": "Drogenkrimi",
-        "Revealed": false
+        "Comment": "Drogenkrimi"
       },
       {
         "Text": "Golden Eye",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Goldfinger",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Leben und sterben lassen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Liebesgr\u00FC\u00DFe aus Moskau",
+        "Text": "Liebesgrüße aus Moskau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Man lebt nur zweimal",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Octopussy",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -4902,200 +4134,168 @@
       {
         "Text": "In the Summertime",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Junge komm bald wieder",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Liebeskummer lohnt sich nicht",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Love me tender",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Marmor, Stein und Eisen bricht",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Mit 17 hat man noch Tr\u00E4ume",
+        "Text": "Mit 17 hat man noch Träume",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Popcorn",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pretty Belinda",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Puppet on a string",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Rote Lippen soll man k\u00FCssen",
+        "Text": "Rote Lippen soll man küssen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Satisfaction",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schuld war nur der Bossa Nova",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "We will rock you",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wild Thing",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Yesterday",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zwei kleine Italiener",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche St\u00E4dte liegen in Baden-W\u00FCrttemberg?",
+    "Text": "Welche Städte liegen in Baden-Württemberg?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Aalen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bruchsal",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Donaueschingen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Freudenstadt",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Friedrichshafen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Heidelberg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Koblenz",
         "Correct": false,
-        "Comment": "Rheinland-Pfalz",
-        "Revealed": false
+        "Comment": "Rheinland-Pfalz"
       },
       {
         "Text": "Konstanz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lindau",
         "Correct": false,
-        "Comment": "Bayern",
-        "Revealed": false
+        "Comment": "Bayern"
       },
       {
         "Text": "Memmingen",
         "Correct": false,
-        "Comment": "Bayern",
-        "Revealed": false
+        "Comment": "Bayern"
       },
       {
-        "Text": "N\u00F6rdlingen",
+        "Text": "Nördlingen",
         "Correct": false,
-        "Comment": "Bayern",
-        "Revealed": false
+        "Comment": "Bayern"
       },
       {
         "Text": "Offenburg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ravensburg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ulm",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Waldshut",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wangen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -5106,98 +4306,82 @@
       {
         "Text": "FC Barcelona",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Arsenal London",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Aston Villa",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Benfica Lissabon",
         "Correct": true,
-        "Comment": "1961/1962",
-        "Revealed": false
+        "Comment": "1961/1962"
       },
       {
         "Text": "FC Liverpool",
         "Correct": true,
-        "Comment": "1977/1978/1981/1984",
-        "Revealed": false
+        "Comment": "1977/1978/1981/1984"
       },
       {
         "Text": "FC Porto",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "FC Valencia",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Feynoord Rotterdam",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Glasgow Rangers",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hamburger SV",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Juventus Turin",
         "Correct": true,
-        "Comment": "1985/1996",
-        "Revealed": false
+        "Comment": "1985/1996"
       },
       {
         "Text": "Nottingham Forest",
         "Correct": true,
-        "Comment": "1979/1980",
-        "Revealed": false
+        "Comment": "1979/1980"
       },
       {
         "Text": "Olympique Marseille",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Roter Stern Belgrad",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Steaua Bukarest",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Werder Bremen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -5208,98 +4392,82 @@
       {
         "Text": "Alaska",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Alberta",
         "Correct": false,
-        "Comment": "Kanada",
-        "Revealed": false
+        "Comment": "Kanada"
       },
       {
         "Text": "Arkansas",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Columbia",
         "Correct": false,
-        "Comment": "Flu\u00DF",
-        "Revealed": false
+        "Comment": "Fluß"
       },
       {
         "Text": "Connecticut",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hawaii",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Maine",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Maryland",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Montana",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ontario",
         "Correct": false,
-        "Comment": "Kanada",
-        "Revealed": false
+        "Comment": "Kanada"
       },
       {
         "Text": "Oregon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rhode Island",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Washington",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wisconsin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wyoming",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "York",
         "Correct": false,
-        "Comment": "England",
-        "Revealed": false
+        "Comment": "England"
       }
     ]
   },
@@ -5310,302 +4478,254 @@
       {
         "Text": "Armin Harry",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bernhard Langer",
         "Correct": false,
-        "Comment": "Golfprofi",
-        "Revealed": false
+        "Comment": "Golfprofi"
       },
       {
         "Text": "Birgit Fischer",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Boris Becker",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Claudia Pechstein",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dieter Baumann",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Franziska von Almsick",
         "Correct": false,
-        "Comment": "Silbermedaillen",
-        "Revealed": false
+        "Comment": "Silbermedaillen"
       },
       {
         "Text": "Heide Rosendahl",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ingrid Mickler",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jan Ullrich",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Josef Neckermann",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rosi Mittermaier",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rudi Altig",
         "Correct": false,
-        "Comment": "Radweltmeister",
-        "Revealed": false
+        "Comment": "Radweltmeister"
       },
       {
         "Text": "Steffi Graf",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Toni Sailer",
         "Correct": false,
-        "Comment": "\u00D6sterreicher",
-        "Revealed": false
+        "Comment": "Österreicher"
       },
       {
         "Text": "Willi Holdorf",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Wobei handelt es sich um Nobelpreistr\u00E4ger?",
+    "Text": "Wobei handelt es sich um Nobelpreisträger?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Albert Einstein",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Alexander Fleming",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Berta von Suttner",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Claus von Klitzing",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Henry Ford",
         "Correct": false,
-        "Comment": "Autokonstrukteur",
-        "Revealed": false
+        "Comment": "Autokonstrukteur"
       },
       {
-        "Text": "Konrad R\u00F6ntgen",
+        "Text": "Konrad Röntgen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lech Walensa",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mahatma Gandhi",
         "Correct": false,
-        "Comment": "ind. Freiheitsk\u00E4mpfer",
-        "Revealed": false
+        "Comment": "ind. Freiheitskämpfer"
       },
       {
         "Text": "Marie Curie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Milton Fridman",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mutter Theresa",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nelson Mandela",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Otto Hahn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Philip Reis",
         "Correct": false,
-        "Comment": "lebte fr\u00FCher",
-        "Revealed": false
+        "Comment": "lebte früher"
       },
       {
         "Text": "Werner von Siemens",
         "Correct": false,
-        "Comment": "lebte fr\u00FCher",
-        "Revealed": false
+        "Comment": "lebte früher"
       },
       {
         "Text": "Willi Brandt",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welches sind deutsche Bundespr\u00E4sidenten und -kanzler?",
+    "Text": "Welches sind deutsche Bundespräsidenten und -kanzler?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "Franz Josef Strau\u00DF",
+        "Text": "Franz Josef Strauß",
         "Correct": false,
-        "Comment": "Kandidat",
-        "Revealed": false
+        "Comment": "Kandidat"
       },
       {
         "Text": "Gustav Heinemann",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gustav Stresemann",
         "Correct": false,
-        "Comment": "Weimarer Republik",
-        "Revealed": false
+        "Comment": "Weimarer Republik"
       },
       {
-        "Text": "Heinrich L\u00FCbke",
+        "Text": "Heinrich Lübke",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Helmut Kohl",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Helmut Schmidt",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Karl Carstens",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kurt Georg Kiesinger",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kurt Schumacher",
         "Correct": false,
-        "Comment": "Kandidat",
-        "Revealed": false
+        "Comment": "Kandidat"
       },
       {
         "Text": "Ludwig Erhardt",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Richard von Weiz\u00E4cker",
+        "Text": "Richard von Weizäcker",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Roman Herzog",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Theodor Heuss",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Walter Scheel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Walter Ulbricht",
         "Correct": false,
-        "Comment": "DDR-Staatsrat",
-        "Revealed": false
+        "Comment": "DDR-Staatsrat"
       },
       {
         "Text": "Willy Brandt",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -5616,200 +4736,168 @@
       {
         "Text": "Der Handschuh",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Ring des Polykrates",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Taucher",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Zauberlehrling",
         "Correct": false,
-        "Comment": "Goethe",
-        "Revealed": false
+        "Comment": "Goethe"
       },
       {
-        "Text": "Die B\u00FCrgschaft",
+        "Text": "Die Bürgschaft",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die Glocke",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die Jungfrau von Orleans",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die Kraniche des Ibikus",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die Rache",
         "Correct": false,
-        "Comment": "Eichendorff",
-        "Revealed": false
+        "Comment": "Eichendorff"
       },
       {
-        "Text": "Die R\u00E4uber",
+        "Text": "Die Räuber",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "G\u00F6tz von Berlichingen",
+        "Text": "Götz von Berlichingen",
         "Correct": false,
-        "Comment": "Goethe",
-        "Revealed": false
+        "Comment": "Goethe"
       },
       {
         "Text": "Kabale und Liebe",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Maria Stuart",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nathan der Weise",
         "Correct": false,
-        "Comment": "Lessing",
-        "Revealed": false
+        "Comment": "Lessing"
       },
       {
         "Text": "Wallenstein",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wilhelm Tell",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Was geh\u00F6rt zu Italien?",
+    "Text": "Was gehört zu Italien?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Ajaccio",
         "Correct": false,
-        "Comment": "Frankreich",
-        "Revealed": false
+        "Comment": "Frankreich"
       },
       {
         "Text": "Ascona",
         "Correct": false,
-        "Comment": "Schweiz",
-        "Revealed": false
+        "Comment": "Schweiz"
       },
       {
         "Text": "Bellinzona",
         "Correct": false,
-        "Comment": "Schweiz",
-        "Revealed": false
+        "Comment": "Schweiz"
       },
       {
         "Text": "Bozen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Catania",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Comer See",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Elba",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Etsch",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "La Valetta",
         "Correct": false,
-        "Comment": "Malta",
-        "Revealed": false
+        "Comment": "Malta"
       },
       {
         "Text": "Meran",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "San Remo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sestriere",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Siena",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tarent",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Triest",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Vesuv",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -5820,200 +4908,168 @@
       {
         "Text": "Aaron",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Absalom",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Benjamin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Elia",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Esau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hiob",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kain",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lazarus",
         "Correct": false,
-        "Comment": "Neues Testament",
-        "Revealed": false
+        "Comment": "Neues Testament"
       },
       {
         "Text": "Lot",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Martha",
         "Correct": false,
-        "Comment": "Neues Testament",
-        "Revealed": false
+        "Comment": "Neues Testament"
       },
       {
         "Text": "Nikodemus",
         "Correct": false,
-        "Comment": "Neues Testament",
-        "Revealed": false
+        "Comment": "Neues Testament"
       },
       {
         "Text": "Noah",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ruth",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Samuel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Saul",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Zach\u00E4us",
+        "Text": "Zachäus",
         "Correct": false,
-        "Comment": "Neues Testament",
-        "Revealed": false
+        "Comment": "Neues Testament"
       }
     ]
   },
   {
-    "Text": "Welche Titel stammen aus Karl May\u0060s gesammelten Werken?",
+    "Text": "Welche Titel stammen aus Karl May`s gesammelten Werken?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Am Jenseits",
         "Correct": true,
-        "Comment": "Band 25",
-        "Revealed": false
+        "Comment": "Band 25"
       },
       {
         "Text": "Am Stillen Ozean",
         "Correct": true,
-        "Comment": "Band 11",
-        "Revealed": false
+        "Comment": "Band 11"
       },
       {
         "Text": "Ardistan",
         "Correct": true,
-        "Comment": "Band 31",
-        "Revealed": false
+        "Comment": "Band 31"
       },
       {
         "Text": "Auf fremden Pfaden",
         "Correct": true,
-        "Comment": "Band 23",
-        "Revealed": false
+        "Comment": "Band 23"
       },
       {
         "Text": "Benito Juarez",
         "Correct": true,
-        "Comment": "Band 53",
-        "Revealed": false
+        "Comment": "Band 53"
       },
       {
         "Text": "Das Buschgespenst",
         "Correct": true,
-        "Comment": "Band 64",
-        "Revealed": false
+        "Comment": "Band 64"
       },
       {
         "Text": "Der letzte Mohikaner",
         "Correct": false,
-        "Comment": "James F. Cooper",
-        "Revealed": false
+        "Comment": "James F. Cooper"
       },
       {
-        "Text": "Der \u00D6lprinz",
+        "Text": "Der Ölprinz",
         "Correct": true,
-        "Comment": "Band 37",
-        "Revealed": false
+        "Comment": "Band 37"
       },
       {
         "Text": "Der Wurzelsepp",
         "Correct": true,
-        "Comment": "Band 68",
-        "Revealed": false
+        "Comment": "Band 68"
       },
       {
-        "Text": "Die Flu\u00DFpiraten vom Mississippi",
+        "Text": "Die Flußpiraten vom Mississippi",
         "Correct": false,
-        "Comment": "Friedrich Gerst\u00E4cker",
-        "Revealed": false
+        "Comment": "Friedrich Gerstäcker"
       },
       {
         "Text": "Die Sklavenkarawane",
         "Correct": true,
-        "Comment": "Band 41",
-        "Revealed": false
+        "Comment": "Band 41"
       },
       {
         "Text": "Lockruf des Goldes",
         "Correct": false,
-        "Comment": "Jack London",
-        "Revealed": false
+        "Comment": "Jack London"
       },
       {
         "Text": "Ritter und Rebellen",
         "Correct": true,
-        "Comment": "Band 69",
-        "Revealed": false
+        "Comment": "Band 69"
       },
       {
-        "Text": "Schlo\u00DF Rodriganda",
+        "Text": "Schloß Rodriganda",
         "Correct": true,
-        "Comment": "Band 51",
-        "Revealed": false
+        "Comment": "Band 51"
       },
       {
         "Text": "Weihnacht",
         "Correct": true,
-        "Comment": "Band 24",
-        "Revealed": false
+        "Comment": "Band 24"
       },
       {
         "Text": "Wildes heiliges Tibet",
         "Correct": false,
-        "Comment": "Sven Hedin",
-        "Revealed": false
+        "Comment": "Sven Hedin"
       }
     ]
   },
@@ -6022,100 +5078,84 @@
     "Selected": false,
     "Answers": [
       {
-        "Text": "A-H\u00F6rnchen",
+        "Text": "A-Hörnchen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Balou",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bambi",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bernhard",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dagobert Duck",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Daniel D\u00FCsentrieb",
+        "Text": "Daniel Düsentrieb",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Foxi",
         "Correct": false,
-        "Comment": "Ralf Kauka",
-        "Revealed": false
+        "Comment": "Ralf Kauka"
       },
       {
         "Text": "Fred Feuerstein",
         "Correct": false,
-        "Comment": "Flintstones",
-        "Revealed": false
+        "Comment": "Flintstones"
       },
       {
         "Text": "Goofy",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Idefix",
         "Correct": false,
-        "Comment": "Uderzo",
-        "Revealed": false
+        "Comment": "Uderzo"
       },
       {
         "Text": "Kater Carlo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lupo",
         "Correct": false,
-        "Comment": "Ralf Kauka",
-        "Revealed": false
+        "Comment": "Ralf Kauka"
       },
       {
         "Text": "Mogli",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Orville",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pluto",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Shirkan",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -6126,200 +5166,168 @@
       {
         "Text": "Achat",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Alexandrit",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Amethyst",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Aquamarin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Aureole",
         "Correct": false,
-        "Comment": "Heiligenschein",
-        "Revealed": false
+        "Comment": "Heiligenschein"
       },
       {
         "Text": "Bergkristall",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bernstein",
         "Correct": false,
-        "Comment": "Harz",
-        "Revealed": false
+        "Comment": "Harz"
       },
       {
         "Text": "Diamant",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gold",
         "Correct": false,
-        "Comment": "Metall",
-        "Revealed": false
+        "Comment": "Metall"
       },
       {
         "Text": "Koralle",
         "Correct": false,
-        "Comment": "Lebewesen",
-        "Revealed": false
+        "Comment": "Lebewesen"
       },
       {
         "Text": "Onyx",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Opal",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rubin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Saphir",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Smaragd",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Topas",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Wobei handelt es sich um Nadelb\u00E4ume?",
+    "Text": "Wobei handelt es sich um Nadelbäume?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Affenbrotbaum",
         "Correct": false,
-        "Comment": "Laubbaum",
-        "Revealed": false
+        "Comment": "Laubbaum"
       },
       {
         "Text": "Eibe",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Erle",
         "Correct": false,
-        "Comment": "Laubbaum",
-        "Revealed": false
+        "Comment": "Laubbaum"
       },
       {
         "Text": "Esche",
         "Correct": false,
-        "Comment": "Laubbaum",
-        "Revealed": false
+        "Comment": "Laubbaum"
       },
       {
-        "Text": "F\u00F6hre",
+        "Text": "Föhre",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kiefer",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "L\u00E4rche",
+        "Text": "Lärche",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Latsche",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mammutbaum",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pappel",
         "Correct": false,
-        "Comment": "Laubbaum",
-        "Revealed": false
+        "Comment": "Laubbaum"
       },
       {
         "Text": "Pinie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tanne",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Thuja",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wacholder",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zeder",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zypresse",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -6330,200 +5338,168 @@
       {
         "Text": "American Dream",
         "Correct": true,
-        "Comment": "Miss Saigon",
-        "Revealed": false
+        "Comment": "Miss Saigon"
       },
       {
         "Text": "Aquarius",
         "Correct": true,
-        "Comment": "Hair",
-        "Revealed": false
+        "Comment": "Hair"
       },
       {
-        "Text": "Don\u0060t cry for me",
+        "Text": "Don`t cry for me",
         "Correct": true,
-        "Comment": "Evita",
-        "Revealed": false
+        "Comment": "Evita"
       },
       {
-        "Text": "Es gr\u00FCnt so gr\u00FCn",
+        "Text": "Es grünt so grün",
         "Correct": true,
-        "Comment": "My fair Lady",
-        "Revealed": false
+        "Comment": "My fair Lady"
       },
       {
         "Text": "Ich habe die goldene Sonne",
         "Correct": true,
-        "Comment": "Annie get your gun",
-        "Revealed": false
+        "Comment": "Annie get your gun"
       },
       {
-        "Text": "It\u0060s time to say good bye",
+        "Text": "It`s time to say good bye",
         "Correct": false,
-        "Comment": "Schlager",
-        "Revealed": false
+        "Comment": "Schlager"
       },
       {
-        "Text": "K\u00F6nigin der Nacht",
+        "Text": "Königin der Nacht",
         "Correct": false,
-        "Comment": "Zauberfl\u00F6te (Oper)",
-        "Revealed": false
+        "Comment": "Zauberflöte (Oper)"
       },
       {
         "Text": "Lokomotion",
         "Correct": true,
-        "Comment": "Starlight Express",
-        "Revealed": false
+        "Comment": "Starlight Express"
       },
       {
         "Text": "Maria",
         "Correct": true,
-        "Comment": "Westside Story",
-        "Revealed": false
+        "Comment": "Westside Story"
       },
       {
         "Text": "Mecky Messer",
         "Correct": false,
-        "Comment": "Dreigroschenoper (Oper)",
-        "Revealed": false
+        "Comment": "Dreigroschenoper (Oper)"
       },
       {
         "Text": "Memories",
         "Correct": true,
-        "Comment": "Cats",
-        "Revealed": false
+        "Comment": "Cats"
       },
       {
         "Text": "Musik der Nacht",
         "Correct": true,
-        "Comment": "Phantom der Oper",
-        "Revealed": false
+        "Comment": "Phantom der Oper"
       },
       {
         "Text": "Schlag nach bei Shakespeare",
         "Correct": true,
-        "Comment": "Kiss me Kate",
-        "Revealed": false
+        "Comment": "Kiss me Kate"
       },
       {
-        "Text": "Was kann der Sigesmund daf\u00FCr",
+        "Text": "Was kann der Sigesmund dafür",
         "Correct": false,
-        "Comment": "Wei\u00DFes R\u00F6ssel (Operette)",
-        "Revealed": false
+        "Comment": "Weißes Rössel (Operette)"
       },
       {
-        "Text": "Wenn ich einmal Reich w\u00E4r",
+        "Text": "Wenn ich einmal Reich wär",
         "Correct": true,
-        "Comment": "Anatevka",
-        "Revealed": false
+        "Comment": "Anatevka"
       },
       {
         "Text": "Willkommen",
         "Correct": true,
-        "Comment": "Cabaret",
-        "Revealed": false
+        "Comment": "Cabaret"
       }
     ]
   },
   {
-    "Text": "Wobei handelt es sich um M\u00E4rchen der Gebr\u00FCder Grimm?",
+    "Text": "Wobei handelt es sich um Märchen der Gebrüder Grimm?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Aschenputtel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Das h\u00E4\u00DFliche Entlein",
+        "Text": "Das häßliche Entlein",
         "Correct": false,
-        "Comment": "Hans-Christian Andersen",
-        "Revealed": false
+        "Comment": "Hans-Christian Andersen"
       },
       {
         "Text": "Das tapfere Schneiderlein",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Fischer und seine Frau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Der Froschk\u00F6nig",
+        "Text": "Der Froschkönig",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der gestiefelte Kater",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die formme Helene",
         "Correct": false,
-        "Comment": "Wilhelm Busch",
-        "Revealed": false
+        "Comment": "Wilhelm Busch"
       },
       {
         "Text": "Die sieben Schwaben",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Dornr\u00F6schen",
+        "Text": "Dornröschen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hase und Igel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "K\u00F6nig Drosselbart",
+        "Text": "König Drosselbart",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rumpelstilzchen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schneewittchen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sindbad, der Seefahrer",
         "Correct": false,
-        "Comment": "1001 Nacht",
-        "Revealed": false
+        "Comment": "1001 Nacht"
       },
       {
         "Text": "Sternthaler",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zwerg Nase",
         "Correct": false,
-        "Comment": "Wilhelm Hauff",
-        "Revealed": false
+        "Comment": "Wilhelm Hauff"
       }
     ]
   },
@@ -6532,100 +5508,84 @@
     "Selected": false,
     "Answers": [
       {
-        "Text": "Albrecht D\u00FCrer",
+        "Text": "Albrecht Dürer",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Fernando Magellan",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Galileo Galilei",
         "Correct": false,
-        "Comment": "1564-1642",
-        "Revealed": false
+        "Comment": "1564-1642"
       },
       {
-        "Text": "G\u00F6tz von Berlichingen",
+        "Text": "Götz von Berlichingen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Heinrich VIII von England",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ignatius von Loyola",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Jeanne d\u0060Arc",
+        "Text": "Jeanne d`Arc",
         "Correct": false,
-        "Comment": "1412-1431",
-        "Revealed": false
+        "Comment": "1412-1431"
       },
       {
         "Text": "Johann Calvin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Johannes Gutenberg",
         "Correct": false,
-        "Comment": "1395-1468",
-        "Revealed": false
+        "Comment": "1395-1468"
       },
       {
         "Text": "Karl V",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lukas Cranach",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Michelangelo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Peter der Gro\u00DFe",
+        "Text": "Peter der Große",
         "Correct": false,
-        "Comment": "1672-1725",
-        "Revealed": false
+        "Comment": "1672-1725"
       },
       {
         "Text": "Philipp Melanchthon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Thomas M\u00FCnzer",
+        "Text": "Thomas Münzer",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ulrich Zwingli",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -6636,98 +5596,82 @@
       {
         "Text": "Badminton",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Baseball",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Beachvolleyball",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cricket",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Taekwondo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Golf",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Judo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kanuslalom",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Karate",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Reiten",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Bogenschie\u00DFen",
+        "Text": "Bogenschießen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wasserball",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Synchronschwimmen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Trampolin",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Triathlon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "BMX",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -6738,302 +5682,254 @@
       {
         "Text": "All you need is love",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Back in the USSR",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Get back",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Help",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Let it be",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Massachusetts",
         "Correct": false,
-        "Comment": "Bee Gees",
-        "Revealed": false
+        "Comment": "Bee Gees"
       },
       {
         "Text": "Mull of Kentyre",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ob la di, Ob la da",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Penny Lane",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Rock\u0060n Roll Music",
+        "Text": "Rock`n Roll Music",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Satisfaction",
         "Correct": false,
-        "Comment": "Rolling Stones",
-        "Revealed": false
+        "Comment": "Rolling Stones"
       },
       {
         "Text": "She loves you",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "The Ferry cross the Mercy",
         "Correct": false,
-        "Comment": "Gerry and the Peacemakers",
-        "Revealed": false
+        "Comment": "Gerry and the Peacemakers"
       },
       {
         "Text": "Yellow Submarine",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Yesterday",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Yesterday Man",
         "Correct": false,
-        "Comment": "Chris Andrews",
-        "Revealed": false
+        "Comment": "Chris Andrews"
       }
     ]
   },
   {
-    "Text": "Was sind Nebenfl\u00FCsse des Rheins?",
+    "Text": "Was sind Nebenflüsse des Rheins?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Aare",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ahr",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Alb",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Aller",
         "Correct": false,
-        "Comment": "Weser",
-        "Revealed": false
+        "Comment": "Weser"
       },
       {
         "Text": "ILL",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lahn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lippe",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Main",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Naab",
         "Correct": false,
-        "Comment": "Donau",
-        "Revealed": false
+        "Comment": "Donau"
       },
       {
         "Text": "Nahe",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Neckar",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ruhr",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Saale",
         "Correct": false,
-        "Comment": "Elbe",
-        "Revealed": false
+        "Comment": "Elbe"
       },
       {
         "Text": "Saar",
         "Correct": false,
-        "Comment": "Mosel",
-        "Revealed": false
+        "Comment": "Mosel"
       },
       {
         "Text": "Sieg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wutach",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Was geh\u00F6rt zu Frankreich?",
+    "Text": "Was gehört zu Frankreich?",
     "Selected": true,
     "Answers": [
       {
         "Text": "Bastia",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Belfort",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Biarritz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cannes",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cevennen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Chaleroi",
         "Correct": false,
-        "Comment": "Belgien",
-        "Revealed": false
+        "Comment": "Belgien"
       },
       {
         "Text": "Dudelange",
         "Correct": false,
-        "Comment": "Luxemburg",
-        "Revealed": false
+        "Comment": "Luxemburg"
       },
       {
         "Text": "Guadeloupe",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gurnsey",
         "Correct": false,
-        "Comment": "Gro\u00DFbritannien",
-        "Revealed": false
+        "Comment": "Großbritannien"
       },
       {
         "Text": "Korsika",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Maas",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Metz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Montreux",
         "Correct": false,
-        "Comment": "Schweiz",
-        "Revealed": false
+        "Comment": "Schweiz"
       },
       {
         "Text": "Roubaix",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Saargem\u00FCnd",
+        "Text": "Saargemünd",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tarn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -7044,98 +5940,82 @@
       {
         "Text": "Ave verum",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bastien und Bastienne",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cosi fan tutte",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Das Veilchen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Zauberer",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Die Entf\u00FChrung aus dem Serail",
+        "Text": "Die Entführung aus dem Serail",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die Forelle",
         "Correct": false,
-        "Comment": "Schubert",
-        "Revealed": false
+        "Comment": "Schubert"
       },
       {
-        "Text": "Die Zauberfl\u00F6te",
+        "Text": "Die Zauberflöte",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Don Giovanni",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Don Juan",
         "Correct": false,
-        "Comment": "Schiller",
-        "Revealed": false
+        "Comment": "Schiller"
       },
       {
         "Text": "Fidelio",
         "Correct": false,
-        "Comment": "Beethoven",
-        "Revealed": false
+        "Comment": "Beethoven"
       },
       {
         "Text": "Figaros Hochzeit",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Idomeneo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kleine Nachtmusik",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Komm lieber Mai",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nabucco",
         "Correct": false,
-        "Comment": "Verdi",
-        "Revealed": false
+        "Comment": "Verdi"
       }
     ]
   },
@@ -7146,98 +6026,82 @@
       {
         "Text": "2",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "21",
         "Correct": false,
-        "Comment": "3x7",
-        "Revealed": false
+        "Comment": "3x7"
       },
       {
         "Text": "53",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "89",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "107",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "109",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "111",
         "Correct": false,
-        "Comment": "37x3",
-        "Revealed": false
+        "Comment": "37x3"
       },
       {
         "Text": "113",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "117",
         "Correct": false,
-        "Comment": "13x9",
-        "Revealed": false
+        "Comment": "13x9"
       },
       {
         "Text": "127",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "129",
         "Correct": false,
-        "Comment": "43x3",
-        "Revealed": false
+        "Comment": "43x3"
       },
       {
         "Text": "131",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "139",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "143",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "151",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "173",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -7248,506 +6112,426 @@
       {
         "Text": "1000 km",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Baccarat",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Backgammon",
         "Correct": false,
-        "Comment": "Brettspiel",
-        "Revealed": false
+        "Comment": "Brettspiel"
       },
       {
         "Text": "Black Jack",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bridge",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Canaster",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Elfer raus",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Go",
         "Correct": false,
-        "Comment": "Brettspiel",
-        "Revealed": false
+        "Comment": "Brettspiel"
       },
       {
         "Text": "Kniffel",
         "Correct": false,
-        "Comment": "W\u00FCrfelspiel",
-        "Revealed": false
+        "Comment": "Würfelspiel"
       },
       {
         "Text": "Poker",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Romm\u00E8e",
+        "Text": "Rommèe",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schafskopf",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Scrabble",
         "Correct": false,
-        "Comment": "Buchstabenlegespiel",
-        "Revealed": false
+        "Comment": "Buchstabenlegespiel"
       },
       {
         "Text": "Skat",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Speed",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Uno",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Bei welchen Personen handelt es sich um griechische G\u00F6tter?",
+    "Text": "Bei welchen Personen handelt es sich um griechische Götter?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Apollon",
         "Correct": true,
-        "Comment": "Gott der Weisheit",
-        "Revealed": false
+        "Comment": "Gott der Weisheit"
       },
       {
         "Text": "Ares",
         "Correct": true,
-        "Comment": "Kriegsgott",
-        "Revealed": false
+        "Comment": "Kriegsgott"
       },
       {
         "Text": "Artemis",
         "Correct": true,
-        "Comment": "Jagdg\u00F6ttin",
-        "Revealed": false
+        "Comment": "Jagdgöttin"
       },
       {
         "Text": "Aurora",
         "Correct": false,
-        "Comment": "r\u00F6m. G\u00F6ttin der Morgenr\u00F6te",
-        "Revealed": false
+        "Comment": "röm. Göttin der Morgenröte"
       },
       {
         "Text": "Demeter",
         "Correct": true,
-        "Comment": "G\u00F6ttin des Ackerbaues",
-        "Revealed": false
+        "Comment": "Göttin des Ackerbaues"
       },
       {
         "Text": "Dionysos",
         "Correct": true,
-        "Comment": "Gott des Weines",
-        "Revealed": false
+        "Comment": "Gott des Weines"
       },
       {
         "Text": "Gaia",
         "Correct": true,
-        "Comment": "Urmutter der Erde",
-        "Revealed": false
+        "Comment": "Urmutter der Erde"
       },
       {
         "Text": "Hades",
         "Correct": true,
-        "Comment": "Gott der Unterwelt",
-        "Revealed": false
+        "Comment": "Gott der Unterwelt"
       },
       {
         "Text": "Helios",
         "Correct": true,
-        "Comment": "Sonnengott",
-        "Revealed": false
+        "Comment": "Sonnengott"
       },
       {
         "Text": "Hera",
         "Correct": true,
-        "Comment": "Gemahlin des Zeus",
-        "Revealed": false
+        "Comment": "Gemahlin des Zeus"
       },
       {
         "Text": "Hermes",
         "Correct": true,
-        "Comment": "G\u00F6tterbote",
-        "Revealed": false
+        "Comment": "Götterbote"
       },
       {
         "Text": "Osiris",
         "Correct": false,
-        "Comment": "\u00E4gypt. Gott",
-        "Revealed": false
+        "Comment": "ägypt. Gott"
       },
       {
         "Text": "Pan",
         "Correct": true,
-        "Comment": "Hirtengott",
-        "Revealed": false
+        "Comment": "Hirtengott"
       },
       {
         "Text": "Tethys",
         "Correct": true,
-        "Comment": "G\u00F6ttin der Feuchtigkeit",
-        "Revealed": false
+        "Comment": "Göttin der Feuchtigkeit"
       },
       {
         "Text": "Venus",
         "Correct": false,
-        "Comment": "r\u00F6m. Liebesg\u00F6ttin",
-        "Revealed": false
+        "Comment": "röm. Liebesgöttin"
       },
       {
         "Text": "Vulcanus",
         "Correct": false,
-        "Comment": "r\u00F6m. Gott des Feuers",
-        "Revealed": false
+        "Comment": "röm. Gott des Feuers"
       }
     ]
   },
   {
-    "Text": "Welche Staaten waren Veranstalter von Fu\u00DFballweltmeisterschaften?",
+    "Text": "Welche Staaten waren Veranstalter von Fußballweltmeisterschaften?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Spanien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Argentinien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Australien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Chile",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "England",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Italien",
         "Correct": true,
-        "Comment": "1934 u. 1990",
-        "Revealed": false
+        "Comment": "1934 u. 1990"
       },
       {
         "Text": "Japan",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kolumbien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mexiko",
         "Correct": true,
-        "Comment": "1970 u. 1986",
-        "Revealed": false
+        "Comment": "1970 u. 1986"
       },
       {
         "Text": "Niederlande",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schweden",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schweiz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "S\u00FCdkorea",
+        "Text": "Südkorea",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ungarn",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Uruguay",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "USA",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welches sind Staaten ohne Meeresk\u00FCste?",
+    "Text": "Welches sind Staaten ohne Meeresküste?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Bolivien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Burkina Faso",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Georgien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mali",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mongolei",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nepal",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Niger",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Paraguay",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ruanda",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sambia",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Slowenien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sudan",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tschad",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tschechien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ungarn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Uruguay",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Was geh\u00F6rt zu einem Computer?",
+    "Text": "Was gehört zu einem Computer?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Browser",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Chip",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Curler",
         "Correct": false,
-        "Comment": "Fitnessger\u00E4t",
-        "Revealed": false
+        "Comment": "Fitnessgerät"
       },
       {
         "Text": "Cursor",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Diskette",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Expander",
         "Correct": false,
-        "Comment": "Muskeltrainer",
-        "Revealed": false
+        "Comment": "Muskeltrainer"
       },
       {
         "Text": "Joystick",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Keyboard",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kompander",
         "Correct": false,
-        "Comment": "Rauschunterdr\u00FCckung",
-        "Revealed": false
+        "Comment": "Rauschunterdrückung"
       },
       {
         "Text": "Modem",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mouse",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pinpad",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Scanner",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Touchscreen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Transponder",
         "Correct": false,
-        "Comment": "Daten\u00FCbertrager",
-        "Revealed": false
+        "Comment": "Datenübertrager"
       },
       {
         "Text": "Worm",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -7758,200 +6542,168 @@
       {
         "Text": "Americium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Astat",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Berkelium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Blei",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Curium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Fermium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Helium",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lawrencium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nobelium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Plutonium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Polonium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Radium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Radon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Uran",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wismut",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wolfram",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Was sind St\u00FCck- oder Z\u00E4hlma\u00DFe?",
+    "Text": "Was sind Stück- oder Zählmaße?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Ballen",
         "Correct": false,
-        "Comment": "Papierma\u00DF",
-        "Revealed": false
+        "Comment": "Papiermaß"
       },
       {
         "Text": "Bund",
         "Correct": true,
-        "Comment": "30 St\u00FCck",
-        "Revealed": false
+        "Comment": "30 Stück"
       },
       {
         "Text": "Dutzend",
         "Correct": true,
-        "Comment": "12 St\u00FCck",
-        "Revealed": false
+        "Comment": "12 Stück"
       },
       {
         "Text": "Gros",
         "Correct": true,
-        "Comment": "144 St\u00FCck",
-        "Revealed": false
+        "Comment": "144 Stück"
       },
       {
         "Text": "Mandel",
         "Correct": true,
-        "Comment": "16 St\u00FCck",
-        "Revealed": false
+        "Comment": "16 Stück"
       },
       {
         "Text": "Mille",
         "Correct": true,
-        "Comment": "1000 St\u00FCck",
-        "Revealed": false
+        "Comment": "1000 Stück"
       },
       {
         "Text": "Morgen",
         "Correct": false,
-        "Comment": "Fl\u00E4chenma\u00DF",
-        "Revealed": false
+        "Comment": "Flächenmaß"
       },
       {
         "Text": "Paar",
         "Correct": true,
-        "Comment": "2 St\u00FCck",
-        "Revealed": false
+        "Comment": "2 Stück"
       },
       {
         "Text": "Pack",
         "Correct": true,
-        "Comment": "15 St\u00FCck",
-        "Revealed": false
+        "Comment": "15 Stück"
       },
       {
         "Text": "Pfund",
         "Correct": false,
-        "Comment": "Gewichtsma\u00DF",
-        "Revealed": false
+        "Comment": "Gewichtsmaß"
       },
       {
         "Text": "Ring",
         "Correct": true,
-        "Comment": "240 St\u00FCck",
-        "Revealed": false
+        "Comment": "240 Stück"
       },
       {
         "Text": "Schock",
         "Correct": true,
-        "Comment": "60 St\u00FCck",
-        "Revealed": false
+        "Comment": "60 Stück"
       },
       {
         "Text": "Ster",
         "Correct": false,
-        "Comment": "Holzma\u00DF",
-        "Revealed": false
+        "Comment": "Holzmaß"
       },
       {
         "Text": "Stiege",
         "Correct": true,
-        "Comment": "20 St\u00FCck",
-        "Revealed": false
+        "Comment": "20 Stück"
       },
       {
         "Text": "Webe",
         "Correct": true,
-        "Comment": "72 St\u00FCck",
-        "Revealed": false
+        "Comment": "72 Stück"
       },
       {
         "Text": "Zimmer",
         "Correct": true,
-        "Comment": "40 St\u00FCck",
-        "Revealed": false
+        "Comment": "40 Stück"
       }
     ]
   },
@@ -7962,1016 +6714,856 @@
       {
         "Text": "Algier",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Athen",
         "Correct": false,
-        "Comment": "13:00 Uhr",
-        "Revealed": false
+        "Comment": "13:00 Uhr"
       },
       {
         "Text": "Barcelona",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Budapest",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hammerfest",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kaliningrad",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kapstadt",
         "Correct": false,
-        "Comment": "13:00 Uhr",
-        "Revealed": false
+        "Comment": "13:00 Uhr"
       },
       {
         "Text": "Kopenhagen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lagos",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lissabon",
         "Correct": false,
-        "Comment": "11:00 Uhr",
-        "Revealed": false
+        "Comment": "11:00 Uhr"
       },
       {
         "Text": "London",
         "Correct": false,
-        "Comment": "11:00 Uhr",
-        "Revealed": false
+        "Comment": "11:00 Uhr"
       },
       {
         "Text": "Prag",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rom",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tirana",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tunis",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Warschau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "In welchen L\u00E4ndern zahlt man mit Euro?",
+    "Text": "In welchen Ländern zahlt man mit Euro?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Andorra",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Belgien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "D\u00E4nemark",
+        "Text": "Dänemark",
         "Correct": false,
-        "Comment": "D\u00E4nische Krone",
-        "Revealed": false
+        "Comment": "Dänische Krone"
       },
       {
         "Text": "England",
         "Correct": false,
-        "Comment": "Pfund",
-        "Revealed": false
+        "Comment": "Pfund"
       },
       {
         "Text": "Finnland",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gibraltar",
         "Correct": false,
-        "Comment": "Pfund",
-        "Revealed": false
+        "Comment": "Pfund"
       },
       {
         "Text": "Griechenland",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Irland",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Liechtenstein",
         "Correct": false,
-        "Comment": "Schweizer Franken",
-        "Revealed": false
+        "Comment": "Schweizer Franken"
       },
       {
         "Text": "Luxemburg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Martinique",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Monaco",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "\u00D6sterreich",
+        "Text": "Österreich",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Portugal",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "San Marino",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Vatikan",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Was geh\u00F6rt zu Th\u00FCringen?",
+    "Text": "Was gehört zu Thüringen?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Arnstadt",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Coburg",
         "Correct": false,
-        "Comment": "Bayern",
-        "Revealed": false
+        "Comment": "Bayern"
       },
       {
         "Text": "Gotha",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Gro\u00DFer Beerberg",
+        "Text": "Großer Beerberg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jena",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "K\u00F6stritz",
+        "Text": "Köstritz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Kyffh\u00E4user Berge",
+        "Text": "Kyffhäuser Berge",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nordhausen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Oberhof",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Oberwiesenthal",
         "Correct": false,
-        "Comment": "Sachsen",
-        "Revealed": false
+        "Comment": "Sachsen"
       },
       {
         "Text": "Plauen",
         "Correct": false,
-        "Comment": "Sachsen",
-        "Revealed": false
+        "Comment": "Sachsen"
       },
       {
         "Text": "Saalfeld",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sangershausen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schmalkalden",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Suhl",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wernigerode",
         "Correct": false,
-        "Comment": "Sachsen-Anhalt",
-        "Revealed": false
+        "Comment": "Sachsen-Anhalt"
       }
     ]
   },
   {
-    "Text": "Welches sind ber\u00FChmte Maler?",
+    "Text": "Welches sind berühmte Maler?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "Albrecht D\u00FCrer",
+        "Text": "Albrecht Dürer",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Balthasar Neumann",
         "Correct": false,
-        "Comment": "Baumeister",
-        "Revealed": false
+        "Comment": "Baumeister"
       },
       {
         "Text": "Caspar David Friedrich",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Claude Monet",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "El Cid",
         "Correct": false,
-        "Comment": "span. Nationalheld",
-        "Revealed": false
+        "Comment": "span. Nationalheld"
       },
       {
         "Text": "El Greco",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Emil Nolde",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Franz Marc",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "K\u00E4the Kollwitz",
+        "Text": "Käthe Kollwitz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Max Frisch",
         "Correct": false,
-        "Comment": "Schriftsteller",
-        "Revealed": false
+        "Comment": "Schriftsteller"
       },
       {
         "Text": "Mies van der Rohe",
         "Correct": false,
-        "Comment": "Architekt",
-        "Revealed": false
+        "Comment": "Architekt"
       },
       {
         "Text": "Paul Cezanne",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Paul Klee",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Paula Modersohn-Becker",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Salvatore Dali",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tizian",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche Vereine waren bisher schon einmal Dt. Fu\u00DFballmeister?",
+    "Text": "Welche Vereine waren bisher schon einmal Dt. Fußballmeister?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Bayer 04 Leverkusen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Eintracht Frankfurt",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Fortuna D\u00FCsseldorf",
+        "Text": "Fortuna Düsseldorf",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Holstein Kiel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Karlsruher FV",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kickers Offenbach",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "MSV Duisburg",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rapid Wien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Rot-Wei\u00DF Essen",
+        "Text": "Rot-Weiß Essen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Spvgg F\u00FCrth",
+        "Text": "Spvgg Fürth",
         "Correct": true,
-        "Comment": "1914,1926,1929",
-        "Revealed": false
+        "Comment": "1914,1926,1929"
       },
       {
         "Text": "SV Hannover 96",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "TSV 1860 M\u00FCnchen",
+        "Text": "TSV 1860 München",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "VfB Leipzig",
         "Correct": true,
-        "Comment": "1903,1906,1913",
-        "Revealed": false
+        "Comment": "1903,1906,1913"
       },
       {
         "Text": "VfL Bochum",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "VfR Mannheim",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Viktoria 89 Berlin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Was sind Nebenfl\u00FCsse der Donau?",
+    "Text": "Was sind Nebenflüsse der Donau?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "Altm\u00FChl",
+        "Text": "Altmühl",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Drau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Eger",
         "Correct": false,
-        "Comment": "Nebenflu\u00DF der Moldau",
-        "Revealed": false
+        "Comment": "Nebenfluß der Moldau"
       },
       {
-        "Text": "G\u00FCnz",
+        "Text": "Günz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Iller",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Isar",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lech",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Murg",
         "Correct": false,
-        "Comment": "Nebenflu\u00DF des Rheins",
-        "Revealed": false
+        "Comment": "Nebenfluß des Rheins"
       },
       {
         "Text": "Naab",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Regen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Salzach",
         "Correct": false,
-        "Comment": "Nebenflu\u00DF des Inn",
-        "Revealed": false
+        "Comment": "Nebenfluß des Inn"
       },
       {
         "Text": "Save",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tauber",
         "Correct": false,
-        "Comment": "Nebenflu\u00DF des Mains",
-        "Revealed": false
+        "Comment": "Nebenfluß des Mains"
       },
       {
-        "Text": "Thei\u00DF",
+        "Text": "Theiß",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Traun",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "W\u00FCrm",
+        "Text": "Würm",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Was geh\u00F6rt zu Gro\u00DFbritannien?",
+    "Text": "Was gehört zu Großbritannien?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Canterbury",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cardiff",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Clyde",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Devon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Edingburgh",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Georgetown",
         "Correct": false,
-        "Comment": "Guyana",
-        "Revealed": false
+        "Comment": "Guyana"
       },
       {
         "Text": "Jersey",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Limerick",
         "Correct": false,
-        "Comment": "Irland",
-        "Revealed": false
+        "Comment": "Irland"
       },
       {
         "Text": "Llandudno",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Loch Ness",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nottingham",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Port Elisabeth",
         "Correct": false,
-        "Comment": "S\u00FCdafrika",
-        "Revealed": false
+        "Comment": "Südafrika"
       },
       {
         "Text": "Severn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Shannon",
         "Correct": false,
-        "Comment": "Irland",
-        "Revealed": false
+        "Comment": "Irland"
       },
       {
         "Text": "Snowdon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Winchester",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche Tiere geh\u00F6ren zu den Katzen?",
+    "Text": "Welche Tiere gehören zu den Katzen?",
     "Selected": true,
     "Answers": [
       {
         "Text": "Fuchs",
         "Correct": false,
-        "Comment": "Hund",
-        "Revealed": false
+        "Comment": "Hund"
       },
       {
         "Text": "Gepard",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Hy\u00E4ne",
+        "Text": "Hyäne",
         "Correct": false,
-        "Comment": "Hund",
-        "Revealed": false
+        "Comment": "Hund"
       },
       {
         "Text": "Jaguar",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Leopard",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "L\u00F6we",
+        "Text": "Löwe",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Luchs",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Manul",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mungo",
         "Correct": false,
-        "Comment": "Marder",
-        "Revealed": false
+        "Comment": "Marder"
       },
       {
         "Text": "Nebelparder",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ozelot",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Panther",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Puma",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Serval",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tiger",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wombat",
         "Correct": false,
-        "Comment": "Marder",
-        "Revealed": false
+        "Comment": "Marder"
       }
     ]
   },
   {
-    "Text": "Welches sind Stra\u00DFen aus dem Original Monopoly-Spiel?",
+    "Text": "Welches sind Straßen aus dem Original Monopoly-Spiel?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "Badstra\u00DFe",
+        "Text": "Badstraße",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Bismarckstra\u00DFe",
+        "Text": "Bismarckstraße",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Elisenstra\u00DFe",
+        "Text": "Elisenstraße",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Kaiserstra\u00DFe",
+        "Text": "Kaiserstraße",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Lessingstra\u00DFe",
+        "Text": "Lessingstraße",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Luisenstra\u00DFe",
+        "Text": "Luisenstraße",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Museumsstra\u00DFe",
+        "Text": "Museumsstraße",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Opernplatz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pariser Platz",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Parkstra\u00DFe",
+        "Text": "Parkstraße",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Poststra\u00DFe",
+        "Text": "Poststraße",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Rathausstra\u00DFe",
+        "Text": "Rathausstraße",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schlossallee",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Seestra\u00DFe",
+        "Text": "Seestraße",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Turmstra\u00DFe",
+        "Text": "Turmstraße",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Wiener Stra\u00DFe",
+        "Text": "Wiener Straße",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Was geh\u00F6rt zu Schleswig - Holstein?",
+    "Text": "Was gehört zu Schleswig - Holstein?",
     "Selected": true,
     "Answers": [
       {
         "Text": "Bad Doberan",
         "Correct": false,
-        "Comment": "Mecklenburg",
-        "Revealed": false
+        "Comment": "Mecklenburg"
       },
       {
-        "Text": "B\u00FCsum",
+        "Text": "Büsum",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cuxhaven",
         "Correct": false,
-        "Comment": "Niedersachsen",
-        "Revealed": false
+        "Comment": "Niedersachsen"
       },
       {
-        "Text": "Dageb\u00FCll",
+        "Text": "Dagebüll",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dithmarschen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Eider",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Eutin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Fehmarn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Heide",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Helgoland",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Norderney",
         "Correct": false,
-        "Comment": "Niedersachsen",
-        "Revealed": false
+        "Comment": "Niedersachsen"
       },
       {
-        "Text": "Pl\u00F6ner See",
+        "Text": "Plöner See",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rendsburg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schlei",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Travem\u00FCnde",
+        "Text": "Travemünde",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wilhelmshaven",
         "Correct": false,
-        "Comment": "Niedersachsen",
-        "Revealed": false
+        "Comment": "Niedersachsen"
       }
     ]
   },
@@ -8980,304 +7572,256 @@
     "Selected": false,
     "Answers": [
       {
-        "Text": "Das G\u00F6ttliche",
+        "Text": "Das Göttliche",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Kampf mit dem Drachen",
         "Correct": false,
-        "Comment": "Schiller",
-        "Revealed": false
+        "Comment": "Schiller"
       },
       {
-        "Text": "Der K\u00F6nig in Thule",
+        "Text": "Der König in Thule",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Der Rattenf\u00E4nger",
+        "Text": "Der Rattenfänger",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die Braut von Korinth",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die Grenadiere",
         "Correct": false,
-        "Comment": "Heine",
-        "Revealed": false
+        "Comment": "Heine"
       },
       {
         "Text": "Die Sommernacht",
         "Correct": false,
-        "Comment": "Klopstock",
-        "Revealed": false
+        "Comment": "Klopstock"
       },
       {
         "Text": "Egmont",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ein Sommer-nachtstraum",
         "Correct": false,
-        "Comment": "Shakespeare",
-        "Revealed": false
+        "Comment": "Shakespeare"
       },
       {
-        "Text": "Erlk\u00F6nig",
+        "Text": "Erlkönig",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ganymed",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hermann und Dorothea",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Prometheus",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Reineke Fuchs",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wandrers Nachtlied",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "West-\u00F6stlicher Diwan",
+        "Text": "West-östlicher Diwan",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welches sind britische Territorien (abh\u00E4ngige Gebiete)?",
+    "Text": "Welches sind britische Territorien (abhängige Gebiete)?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Anguilla",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bermuda",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cayman Islands",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Falklandinseln",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gibraltar",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Guam",
         "Correct": false,
-        "Comment": "USA",
-        "Revealed": false
+        "Comment": "USA"
       },
       {
         "Text": "Hongkong",
         "Correct": false,
-        "Comment": "China",
-        "Revealed": false
+        "Comment": "China"
       },
       {
         "Text": "Jungferninseln",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Montserrat",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Neukaledonien",
         "Correct": false,
-        "Comment": "Frankreich",
-        "Revealed": false
+        "Comment": "Frankreich"
       },
       {
         "Text": "Pitcairninseln",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "St. Helena",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "St. Lucia",
         "Correct": false,
-        "Comment": "selbst\u00E4ndig",
-        "Revealed": false
+        "Comment": "selbständig"
       },
       {
-        "Text": "S\u00FCd-Georgien",
+        "Text": "Süd-Georgien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tschagos-Inseln",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Turks- und Caicosinseln",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welches sind B\u00FCcher von Jules Verne?",
+    "Text": "Welches sind Bücher von Jules Verne?",
     "Selected": false,
     "Answers": [
       {
         "Text": "20000 Meilen unter den Meeren",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Das Karpatenschloss",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Graf von Montechristo",
         "Correct": false,
-        "Comment": "Dumas",
-        "Revealed": false
+        "Comment": "Dumas"
       },
       {
         "Text": "Der Kurier des Zaren",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die Eissphinx",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die geheimnisvolle Insel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Die Kinder des Kapit\u00E4ns Grant",
+        "Text": "Die Kinder des Kapitäns Grant",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die Zeitmaschine",
         "Correct": false,
-        "Comment": "E.G. Wells",
-        "Revealed": false
+        "Comment": "E.G. Wells"
       },
       {
-        "Text": "F\u00FCnf Wochen im Ballon",
+        "Text": "Fünf Wochen im Ballon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Metropolis",
         "Correct": false,
-        "Comment": "Lang",
-        "Revealed": false
+        "Comment": "Lang"
       },
       {
         "Text": "Moby Dick",
         "Correct": false,
-        "Comment": "Melville",
-        "Revealed": false
+        "Comment": "Melville"
       },
       {
         "Text": "Reise um den Mond",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Reise um die Erde in 80 Tagen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Reise zum Mittelpunkt der Erde",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Von der Erde zum Mond",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zwei Jahre Ferien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -9288,200 +7832,168 @@
       {
         "Text": "Angola",
         "Correct": false,
-        "Comment": "Portugal",
-        "Revealed": false
+        "Comment": "Portugal"
       },
       {
         "Text": "Bismark-Archipel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Burundi",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Elfenbeink\u00FCste",
+        "Text": "Elfenbeinküste",
         "Correct": false,
-        "Comment": "Frankreich",
-        "Revealed": false
+        "Comment": "Frankreich"
       },
       {
         "Text": "Franz-Josefs-Land",
         "Correct": false,
-        "Comment": "Russland",
-        "Revealed": false
+        "Comment": "Russland"
       },
       {
         "Text": "Kamerun",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Karolinen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kiautschu",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Namibia",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nauru",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Neuguinea",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Palau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Philippinen",
         "Correct": false,
-        "Comment": "Spanien",
-        "Revealed": false
+        "Comment": "Spanien"
       },
       {
         "Text": "Samoa",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tanganjeka",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Togo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche dieser deutschen Fu\u00DFballspieler war Weltmeister?",
+    "Text": "Welche dieser deutschen Fußballspieler war Weltmeister?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "Bernd H\u00F6lzenbein",
+        "Text": "Bernd Hölzenbein",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Berti Vogts",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Harald Schuhmacher",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Horst Eckel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Josef Maier",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jupp Posipal",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Karl Mai",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Klaus Augenthaler",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Klaus Fischer",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Matthias Sammer",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rainer Bonhof",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Rudi V\u00F6ller",
+        "Text": "Rudi Völler",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Stefan Reuter",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Thomas H\u00E4\u00DFler",
+        "Text": "Thomas Häßler",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Uwe Seeler",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Werner Liebrich",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -9492,98 +8004,82 @@
       {
         "Text": "Botswana",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Djibouti",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ghana",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kapverden",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kiribati",
         "Correct": false,
-        "Comment": "Ozeanien",
-        "Revealed": false
+        "Comment": "Ozeanien"
       },
       {
         "Text": "Komoren",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lesotho",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Liberia",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Malawi",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Malediven",
         "Correct": false,
-        "Comment": "Asien",
-        "Revealed": false
+        "Comment": "Asien"
       },
       {
         "Text": "Mauritius",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Panama",
         "Correct": false,
-        "Comment": "Mittelamerika",
-        "Revealed": false
+        "Comment": "Mittelamerika"
       },
       {
         "Text": "Ruanda",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Seychellen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Swasiland",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Vanuatu",
         "Correct": false,
-        "Comment": "Ozeanien",
-        "Revealed": false
+        "Comment": "Ozeanien"
       }
     ]
   },
@@ -9594,98 +8090,82 @@
       {
         "Text": "Bauhaus Zentrum",
         "Correct": false,
-        "Comment": "Dessau",
-        "Revealed": false
+        "Comment": "Dessau"
       },
       {
         "Text": "Brandenburger Tor",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Charlottenburger Schloss",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Deutsches Museum",
         "Correct": false,
-        "Comment": "M\u00FCnchen",
-        "Revealed": false
+        "Comment": "München"
       },
       {
         "Text": "Europa-Center",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Fernsehturm am Alex",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Funkturm",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Luftbr\u00FCcken-denkmal",
+        "Text": "Luftbrücken-denkmal",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pergamon-Museum",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Reichstag",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rotes Rathaus",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Schlo\u00DF Sanssoussi",
+        "Text": "Schloß Sanssoussi",
         "Correct": false,
-        "Comment": "Potsdam",
-        "Revealed": false
+        "Comment": "Potsdam"
       },
       {
-        "Text": "Siegess\u00E4ule",
+        "Text": "Siegessäule",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sony-Plaza",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sowjet. Ehrenmahl",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zwinger",
         "Correct": false,
-        "Comment": "Dresden",
-        "Revealed": false
+        "Comment": "Dresden"
       }
     ]
   },
@@ -9696,98 +8176,82 @@
       {
         "Text": "Azoren",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bornholm",
         "Correct": false,
-        "Comment": "Ostsee",
-        "Revealed": false
+        "Comment": "Ostsee"
       },
       {
         "Text": "Falklandinseln",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "F\u00E4r\u00F6er-inseln",
+        "Text": "Färöer-inseln",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Galapagos Inseln",
         "Correct": false,
-        "Comment": "Pazifik",
-        "Revealed": false
+        "Comment": "Pazifik"
       },
       {
         "Text": "Hebriden",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Irland",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Island",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lofoten",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Madeira",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Malta",
         "Correct": false,
-        "Comment": "Mittelmeer",
-        "Revealed": false
+        "Comment": "Mittelmeer"
       },
       {
         "Text": "Neufundland",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sansibar",
         "Correct": false,
-        "Comment": "Indischer Ozean",
-        "Revealed": false
+        "Comment": "Indischer Ozean"
       },
       {
         "Text": "Sao Tome",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "St. Helena",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Teneriffa",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -9798,98 +8262,82 @@
       {
         "Text": "Aal",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Blindschleiche",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Cham\u00E4leon",
+        "Text": "Chamäleon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Frosch",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hai",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kobra",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Krebs",
         "Correct": false,
-        "Comment": "Krebstiere",
-        "Revealed": false
+        "Comment": "Krebstiere"
       },
       {
         "Text": "Pinguin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ratte",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Regenwurm",
         "Correct": false,
-        "Comment": "W\u00FCrmer",
-        "Revealed": false
+        "Comment": "Würmer"
       },
       {
         "Text": "Salamander",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Schildkr\u00F6te",
+        "Text": "Schildkröte",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schnecke",
         "Correct": false,
-        "Comment": "Weichtier",
-        "Revealed": false
+        "Comment": "Weichtier"
       },
       {
         "Text": "Skorpion",
         "Correct": false,
-        "Comment": "Spinnen",
-        "Revealed": false
+        "Comment": "Spinnen"
       },
       {
         "Text": "Storch",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Unke",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -9900,302 +8348,254 @@
       {
         "Text": "Aida",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Anatevka",
         "Correct": false,
-        "Comment": "Musical",
-        "Revealed": false
+        "Comment": "Musical"
       },
       {
         "Text": "Carmen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Carmina Burana",
         "Correct": false,
-        "Comment": "Liedersammlung",
-        "Revealed": false
+        "Comment": "Liedersammlung"
       },
       {
-        "Text": "Der Freisch\u00FCtz",
+        "Text": "Der Freischütz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Rosenkavalier",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die lustigen Weiber von Windsor",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Die Zauberfl\u00F6te",
+        "Text": "Die Zauberflöte",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Feuerwerk",
         "Correct": false,
-        "Comment": "musikal. Kom\u00F6die",
-        "Revealed": false
+        "Comment": "musikal. Komödie"
       },
       {
         "Text": "Fidelio",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "H\u00E4nsel und Gretel",
+        "Text": "Hänsel und Gretel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lohengrin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Madame Butterfly",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pariser Leben",
         "Correct": false,
-        "Comment": "Operrette",
-        "Revealed": false
+        "Comment": "Operrette"
       },
       {
         "Text": "Pique Dame",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Porgy und Bess",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Was geh\u00F6rt zu Spanien?",
+    "Text": "Was gehört zu Spanien?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Cadiz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ceuta",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cordoba",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cuzco",
         "Correct": false,
-        "Comment": "Peru",
-        "Revealed": false
+        "Comment": "Peru"
       },
       {
         "Text": "Elche",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Faro",
         "Correct": false,
-        "Comment": "Portugal",
-        "Revealed": false
+        "Comment": "Portugal"
       },
       {
         "Text": "Formentera",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ibiza",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lanzarote",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Leon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Madeira",
         "Correct": false,
-        "Comment": "Portugal",
-        "Revealed": false
+        "Comment": "Portugal"
       },
       {
         "Text": "Malaga",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mellila",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mendoza",
         "Correct": false,
-        "Comment": "Argentinien",
-        "Revealed": false
+        "Comment": "Argentinien"
       },
       {
         "Text": "San Sebastian",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Vigo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welches sind nordamerikanische Indianerst\u00E4mme?",
+    "Text": "Welches sind nordamerikanische Indianerstämme?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Apachen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cheyenne",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Chiricahuas",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Irokesen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kiowas",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kreolen",
         "Correct": false,
-        "Comment": "Karibik",
-        "Revealed": false
+        "Comment": "Karibik"
       },
       {
         "Text": "Maori",
         "Correct": false,
-        "Comment": "Neuseeland",
-        "Revealed": false
+        "Comment": "Neuseeland"
       },
       {
         "Text": "Massai",
         "Correct": false,
-        "Comment": "Ostafrika",
-        "Revealed": false
+        "Comment": "Ostafrika"
       },
       {
         "Text": "Maya",
         "Correct": false,
-        "Comment": "Mittelamerika",
-        "Revealed": false
+        "Comment": "Mittelamerika"
       },
       {
         "Text": "Mohikaner",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Navajo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nez Perce",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schoschonen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Seminole",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sioux",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ute",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -10206,200 +8606,168 @@
       {
         "Text": "Bernard Hinault",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bjarne Rijs",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Eddy Merckx",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Erich Zabel",
         "Correct": false,
-        "Comment": "Gr\u00FCnes Trikot",
-        "Revealed": false
+        "Comment": "Grünes Trikot"
       },
       {
         "Text": "Fausto Coppi",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Greg Lemond",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jan Ullrich",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jaques Anquetil",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lance Armstrong",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Louison Bobet",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Marco Pantani",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Miquel Indurain",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Olaf Ludwig",
         "Correct": false,
-        "Comment": "Gr\u00FCnes Trikot",
-        "Revealed": false
+        "Comment": "Grünes Trikot"
       },
       {
         "Text": "Pedro Delgado",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Raymond Poulidor",
         "Correct": false,
-        "Comment": "mehrmals 2.",
-        "Revealed": false
+        "Comment": "mehrmals 2."
       },
       {
         "Text": "Richard Virenque",
         "Correct": false,
-        "Comment": "Bergwertung",
-        "Revealed": false
+        "Comment": "Bergwertung"
       }
     ]
   },
   {
-    "Text": "Welche St\u00E4dte liegen auf der Nordosth\u00E4lfte der Weltkugel?",
+    "Text": "Welche Städte liegen auf der Nordosthälfte der Weltkugel?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Aden",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Algier",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Barcelona",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bordeaux",
         "Correct": false,
-        "Comment": "Nordwest",
-        "Revealed": false
+        "Comment": "Nordwest"
       },
       {
         "Text": "Casablanca",
         "Correct": false,
-        "Comment": "Nordwest",
-        "Revealed": false
+        "Comment": "Nordwest"
       },
       {
         "Text": "Djakarta",
         "Correct": false,
-        "Comment": "S\u00FCdost",
-        "Revealed": false
+        "Comment": "Südost"
       },
       {
         "Text": "Frankfurt",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hongkong",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kairo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lissabon",
         "Correct": false,
-        "Comment": "Nordwest",
-        "Revealed": false
+        "Comment": "Nordwest"
       },
       {
         "Text": "Manila",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Oslo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Paris",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rom",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Singapur",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tunis",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -10410,200 +8778,168 @@
       {
         "Text": "Alfa Romeo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Chevrolet",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ferrari",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Havannah",
         "Correct": false,
-        "Comment": "Zigarre",
-        "Revealed": false
+        "Comment": "Zigarre"
       },
       {
         "Text": "Honda",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lada",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lomborghini",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Maserati",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "McLaren",
         "Correct": false,
-        "Comment": "Rennstall",
-        "Revealed": false
+        "Comment": "Rennstall"
       },
       {
         "Text": "Opel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Punto",
         "Correct": false,
-        "Comment": "Auto-Modell von FIAT",
-        "Revealed": false
+        "Comment": "Auto-Modell von FIAT"
       },
       {
         "Text": "Rolls Royce",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Seat",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Toyota",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Volvo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Yamaha",
         "Correct": false,
-        "Comment": "Motorrad",
-        "Revealed": false
+        "Comment": "Motorrad"
       }
     ]
   },
   {
-    "Text": "Staaten mit monarch. Staatsoberh\u00E4uptern?",
+    "Text": "Staaten mit monarch. Staatsoberhäuptern?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Andorra",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Belgien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "D\u00E4nemark",
+        "Text": "Dänemark",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Finnland",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Griechenland",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Gro\u00DFbritannien",
+        "Text": "Großbritannien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Japan",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kanada",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Luxemburg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Monaco",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Niederlande",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Norwegen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "\u00D6sterreich",
+        "Text": "Österreich",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schweden",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Spanien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Thailand",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -10614,200 +8950,168 @@
       {
         "Text": "Cello",
         "Correct": false,
-        "Comment": "Saiteninstrument",
-        "Revealed": false
+        "Comment": "Saiteninstrument"
       },
       {
         "Text": "Cemballo",
         "Correct": false,
-        "Comment": "Tasteninstrument",
-        "Revealed": false
+        "Comment": "Tasteninstrument"
       },
       {
         "Text": "Didgeridoo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dudelsack",
         "Correct": false,
-        "Comment": "Rohrblattinstrument",
-        "Revealed": false
+        "Comment": "Rohrblattinstrument"
       },
       {
         "Text": "Fagott",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Klarinette",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kornett",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lure",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Oboe",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Okarina",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pikkolo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rackett",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schalmei",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Serpent",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Spinett",
         "Correct": false,
-        "Comment": "Tasteninstrument",
-        "Revealed": false
+        "Comment": "Tasteninstrument"
       },
       {
         "Text": "Tuba",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welches sind St\u00E4dte in Rheinland-Pfalz?",
+    "Text": "Welches sind Städte in Rheinland-Pfalz?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Bad Neuenahr",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bingen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bitburg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Idar-Oberstein",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kaiserslautern",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Koblenz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mainz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mannheim",
         "Correct": false,
-        "Comment": "Baden-W\u00FCrttemberg",
-        "Revealed": false
+        "Comment": "Baden-Württemberg"
       },
       {
         "Text": "Merzig",
         "Correct": false,
-        "Comment": "Saarland",
-        "Revealed": false
+        "Comment": "Saarland"
       },
       {
         "Text": "Pirmasens",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "R\u00FCdesheim",
+        "Text": "Rüdesheim",
         "Correct": false,
-        "Comment": "Hessen",
-        "Revealed": false
+        "Comment": "Hessen"
       },
       {
         "Text": "Saarburg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Trier",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wetzlar",
         "Correct": false,
-        "Comment": "Hessen",
-        "Revealed": false
+        "Comment": "Hessen"
       },
       {
         "Text": "Worms",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Zweibr\u00FCcken",
+        "Text": "Zweibrücken",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -10818,200 +9122,168 @@
       {
         "Text": "Adler",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Africa Twin",
         "Correct": true,
-        "Comment": "Honda Africa Twin",
-        "Revealed": false
+        "Comment": "Honda Africa Twin"
       },
       {
         "Text": "Bandit",
         "Correct": true,
-        "Comment": "Suzuki",
-        "Revealed": false
+        "Comment": "Suzuki"
       },
       {
         "Text": "Gold Wing",
         "Correct": true,
-        "Comment": "Honda Gold Wing",
-        "Revealed": false
+        "Comment": "Honda Gold Wing"
       },
       {
-        "Text": "G\u00FCllepumpe",
+        "Text": "Güllepumpe",
         "Correct": true,
-        "Comment": "Honda CX 500",
-        "Revealed": false
+        "Comment": "Honda CX 500"
       },
       {
         "Text": "Gummikuh",
         "Correct": true,
-        "Comment": "alle BMW mit Boxer",
-        "Revealed": false
+        "Comment": "alle BMW mit Boxer"
       },
       {
         "Text": "Intruder",
         "Correct": true,
-        "Comment": "Suzuki",
-        "Revealed": false
+        "Comment": "Suzuki"
       },
       {
         "Text": "Jaguar",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mammut",
         "Correct": true,
-        "Comment": "M\u00FCnch Mammut",
-        "Revealed": false
+        "Comment": "Münch Mammut"
       },
       {
         "Text": "Monster",
         "Correct": true,
-        "Comment": "z.B. Ducati Monster 750",
-        "Revealed": false
+        "Comment": "z.B. Ducati Monster 750"
       },
       {
         "Text": "Puma",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Thunderbird",
         "Correct": true,
-        "Comment": "Triumph Thunderbird Sport",
-        "Revealed": false
+        "Comment": "Triumph Thunderbird Sport"
       },
       {
         "Text": "Tiger",
         "Correct": true,
-        "Comment": "Triumph Tiger",
-        "Revealed": false
+        "Comment": "Triumph Tiger"
       },
       {
         "Text": "Transalp",
         "Correct": true,
-        "Comment": "Honda Transalp",
-        "Revealed": false
+        "Comment": "Honda Transalp"
       },
       {
-        "Text": "Wasserb\u00FCffel",
+        "Text": "Wasserbüffel",
         "Correct": true,
-        "Comment": "Yamaha RD 350",
-        "Revealed": false
+        "Comment": "Yamaha RD 350"
       },
       {
         "Text": "Wonder",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Wer war/ist amerikanischer Pr\u00E4sident?",
+    "Text": "Wer war/ist amerikanischer Präsident?",
     "Selected": true,
     "Answers": [
       {
         "Text": "Abraham Lincoln",
         "Correct": true,
-        "Comment": "1861 - 1865",
-        "Revealed": false
+        "Comment": "1861 - 1865"
       },
       {
         "Text": "Arnold Schwarzenegger",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Benjamin Harrison",
         "Correct": true,
-        "Comment": "1889-1893",
-        "Revealed": false
+        "Comment": "1889-1893"
       },
       {
         "Text": "Bill Clinton",
         "Correct": true,
-        "Comment": "1993-2001",
-        "Revealed": false
+        "Comment": "1993-2001"
       },
       {
         "Text": "Bill Gates",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "George Bush",
         "Correct": true,
-        "Comment": "1989-1993",
-        "Revealed": false
+        "Comment": "1989-1993"
       },
       {
         "Text": "George Washington",
         "Correct": true,
-        "Comment": "1789-1797",
-        "Revealed": false
+        "Comment": "1789-1797"
       },
       {
         "Text": "Gerald Ford",
         "Correct": true,
-        "Comment": "1974-1977",
-        "Revealed": false
+        "Comment": "1974-1977"
       },
       {
         "Text": "Harry Truman",
         "Correct": true,
-        "Comment": "1945-1953",
-        "Revealed": false
+        "Comment": "1945-1953"
       },
       {
         "Text": "Henry Fonda",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "John Carpenter",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "John F. Kennedy",
         "Correct": true,
-        "Comment": "1961-1963",
-        "Revealed": false
+        "Comment": "1961-1963"
       },
       {
         "Text": "Lyndon Johnson",
         "Correct": true,
-        "Comment": "1963-1969",
-        "Revealed": false
+        "Comment": "1963-1969"
       },
       {
         "Text": "Richard Nixon",
         "Correct": true,
-        "Comment": "1969-1974",
-        "Revealed": false
+        "Comment": "1969-1974"
       },
       {
         "Text": "Ronald Reagan",
         "Correct": true,
-        "Comment": "1981-1989",
-        "Revealed": false
+        "Comment": "1981-1989"
       },
       {
         "Text": "Theodore Roosevelt",
         "Correct": true,
-        "Comment": "1901-1909",
-        "Revealed": false
+        "Comment": "1901-1909"
       }
     ]
   },
@@ -11022,98 +9294,82 @@
       {
         "Text": "Alain Prost",
         "Correct": false,
-        "Comment": "1985, 1986, 1989, 1993",
-        "Revealed": false
+        "Comment": "1985, 1986, 1989, 1993"
       },
       {
         "Text": "Alan Jones",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ayrton Senna",
         "Correct": false,
-        "Comment": "1988, 1990, 1991",
-        "Revealed": false
+        "Comment": "1988, 1990, 1991"
       },
       {
         "Text": "Damon Hill",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Damon Hill",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jacques Villeneuve",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "James Hunt",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jochen Rindt",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jody Scheckter",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "John Surtees",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Keke Rosberg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mario Andretti",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Mika H\u00E4kkinen",
+        "Text": "Mika Häkkinen",
         "Correct": false,
-        "Comment": "1998, 1999",
-        "Revealed": false
+        "Comment": "1998, 1999"
       },
       {
         "Text": "Mike Hawthorn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nelson Piquet",
         "Correct": false,
-        "Comment": "1981, 1983, 1987",
-        "Revealed": false
+        "Comment": "1981, 1983, 1987"
       },
       {
         "Text": "Nigel Mansell",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -11124,200 +9380,168 @@
       {
         "Text": "Alexander Vinokurov",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bernard Hinault",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Didi Thurau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Eddy Merckx",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Fausto Coppi",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Ferdi K\u00FCbler",
+        "Text": "Ferdi Kübler",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Greg LeMond",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jan Ulrich",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jaques Anquetil",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Joop Zoetemelk",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Joseba Beloki",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lance Armstrong",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Louison Bobet",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Miguel Indurain",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Raymond Poulidor",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rudi Altig",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welcher Nationalspieler hat mehr Eins\u00E4tze als Andreas Brehme (86)?",
+    "Text": "Welcher Nationalspieler hat mehr Einsätze als Andreas Brehme (86)?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "Andreas K\u00F6pke",
+        "Text": "Andreas Köpke",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Berti Vogts",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Franz Beckenbauer",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Gerd M\u00FCller",
+        "Text": "Gerd Müller",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Hans-J\u00FCrgen D\u00F6rner",
+        "Text": "Hans-Jürgen Dörner",
         "Correct": true,
-        "Comment": "100 (DDR)",
-        "Revealed": false
+        "Comment": "100 (DDR)"
       },
       {
         "Text": "Joachim Streich",
         "Correct": true,
-        "Comment": "102 (DDR)",
-        "Revealed": false
+        "Comment": "102 (DDR)"
       },
       {
-        "Text": "J\u00FCrgen Croy",
+        "Text": "Jürgen Croy",
         "Correct": true,
-        "Comment": "94 (DDR)",
-        "Revealed": false
+        "Comment": "94 (DDR)"
       },
       {
-        "Text": "J\u00FCrgen Klinsmann",
+        "Text": "Jürgen Klinsmann",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "J\u00FCrgen Kohler",
+        "Text": "Jürgen Kohler",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Karl-Heinz F\u00F6rster",
+        "Text": "Karl-Heinz Förster",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Lothar Matth\u00E4us",
+        "Text": "Lothar Matthäus",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Oliver Kahn",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Rudi V\u00F6ller",
+        "Text": "Rudi Völler",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sepp Maier",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Thomas H\u00E4\u00DFler",
+        "Text": "Thomas Häßler",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ulf Kirsten",
         "Correct": true,
-        "Comment": "100 (49 DDR, 51 BRD)",
-        "Revealed": false
+        "Comment": "100 (49 DDR, 51 BRD)"
       }
     ]
   },
@@ -11328,98 +9552,82 @@
       {
         "Text": "Alcatel One Touch 535",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "LG G5400",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Motorola V300",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Motorola v66i",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nokia 3100",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nokia 3410",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sagem MY X-3",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Samsung SGH N500",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Samsung SGH X100",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Samsung SGH-E700",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Siemens A50",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Siemens C25",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Siemens C55",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Siemens ST55",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sony Ericson T610",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sony Ericson Z200",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -11428,100 +9636,84 @@
     "Selected": false,
     "Answers": [
       {
-        "Text": "A hard day\u0027s night",
+        "Text": "A hard day's night",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Get back",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Help",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "I want to hold your Hand",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "In the army now",
         "Correct": false,
-        "Comment": "Status Quo",
-        "Revealed": false
+        "Comment": "Status Quo"
       },
       {
         "Text": "Lady Madonna",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Let it be",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nowhere man",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "OB-LA-DI, OB-LA-DA",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "She loves you",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Smoke on the water",
         "Correct": false,
-        "Comment": "Deep Purple",
-        "Revealed": false
+        "Comment": "Deep Purple"
       },
       {
         "Text": "Waterloo",
         "Correct": false,
-        "Comment": "Abba",
-        "Revealed": false
+        "Comment": "Abba"
       },
       {
         "Text": "We will rock you",
         "Correct": false,
-        "Comment": "Queen",
-        "Revealed": false
+        "Comment": "Queen"
       },
       {
         "Text": "While my guitar gently weeps",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Yellow submarine",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Yesterday",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -11532,302 +9724,254 @@
       {
         "Text": "NSU RO 80",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Aston Martin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Audi A2",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "BMW Z3",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Citroen GS Birotor",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ford Capri",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ford Explorer",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ford Ka",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mazda RX7",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mazda RX8",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "NSU Prinz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Opel Manta",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Porsche 911",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "VW K70",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "VW K\u00E4fer",
+        "Text": "VW Käfer",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "VW New Beatle",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche Autokennzeichen kommen aus Baden-W\u00FCrttemberg?",
+    "Text": "Welche Autokennzeichen kommen aus Baden-Württemberg?",
     "Selected": true,
     "Answers": [
       {
         "Text": "BL",
         "Correct": true,
-        "Comment": "Balingen",
-        "Revealed": false
+        "Comment": "Balingen"
       },
       {
         "Text": "CW",
         "Correct": true,
-        "Comment": "Calw",
-        "Revealed": false
+        "Comment": "Calw"
       },
       {
         "Text": "EM",
         "Correct": true,
-        "Comment": "Emmendingen",
-        "Revealed": false
+        "Comment": "Emmendingen"
       },
       {
         "Text": "EMD",
         "Correct": false,
-        "Comment": "Emden",
-        "Revealed": false
+        "Comment": "Emden"
       },
       {
         "Text": "GF",
         "Correct": false,
-        "Comment": "Gifhorn",
-        "Revealed": false
+        "Comment": "Gifhorn"
       },
       {
         "Text": "GP",
         "Correct": true,
-        "Comment": "G\u00F6ppingen",
-        "Revealed": false
+        "Comment": "Göppingen"
       },
       {
         "Text": "HN",
         "Correct": true,
-        "Comment": "Heilbronn",
-        "Revealed": false
+        "Comment": "Heilbronn"
       },
       {
         "Text": "KN",
         "Correct": true,
-        "Comment": "Konstanz",
-        "Revealed": false
+        "Comment": "Konstanz"
       },
       {
-        "Text": "K\u00DCN",
+        "Text": "KÜN",
         "Correct": true,
-        "Comment": "K\u00FCnzelsau",
-        "Revealed": false
+        "Comment": "Künzelsau"
       },
       {
         "Text": "LB",
         "Correct": true,
-        "Comment": "Ludwigsburg",
-        "Revealed": false
+        "Comment": "Ludwigsburg"
       },
       {
         "Text": "MA",
         "Correct": true,
-        "Comment": "Mannheim",
-        "Revealed": false
+        "Comment": "Mannheim"
       },
       {
         "Text": "SDL",
         "Correct": false,
-        "Comment": "Stendal",
-        "Revealed": false
+        "Comment": "Stendal"
       },
       {
         "Text": "SFA",
         "Correct": false,
-        "Comment": "Soltau-Fallingbostel",
-        "Revealed": false
+        "Comment": "Soltau-Fallingbostel"
       },
       {
         "Text": "SHA",
         "Correct": true,
-        "Comment": "Schw\u00E4bisch Hall",
-        "Revealed": false
+        "Comment": "Schwäbisch Hall"
       },
       {
         "Text": "UL",
         "Correct": true,
-        "Comment": "Ulm",
-        "Revealed": false
+        "Comment": "Ulm"
       },
       {
         "Text": "WN",
         "Correct": true,
-        "Comment": "Rems-Murr-Kreis in Waiblingen",
-        "Revealed": false
+        "Comment": "Rems-Murr-Kreis in Waiblingen"
       }
     ]
   },
   {
-    "Text": "Welche St\u00E4dte liegen s\u00FCdlicher als Freudenstadt?",
+    "Text": "Welche Städte liegen südlicher als Freudenstadt?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Bombay",
         "Correct": true,
-        "Comment": "Indien",
-        "Revealed": false
+        "Comment": "Indien"
       },
       {
         "Text": "Budapest",
         "Correct": true,
-        "Comment": "Ungarn",
-        "Revealed": false
+        "Comment": "Ungarn"
       },
       {
         "Text": "Houston/Amerika",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lausanne",
         "Correct": true,
-        "Comment": "Schweiz",
-        "Revealed": false
+        "Comment": "Schweiz"
       },
       {
         "Text": "Monterrey",
         "Correct": true,
-        "Comment": "Mexico",
-        "Revealed": false
+        "Comment": "Mexico"
       },
       {
         "Text": "Montevideo",
         "Correct": true,
-        "Comment": "Uruguay",
-        "Revealed": false
+        "Comment": "Uruguay"
       },
       {
-        "Text": "M\u00FCnchen",
+        "Text": "München",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "New York",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Paris",
         "Correct": false,
-        "Comment": "Frankreich",
-        "Revealed": false
+        "Comment": "Frankreich"
       },
       {
         "Text": "Prag",
         "Correct": false,
-        "Comment": "Tschechoslowakei",
-        "Revealed": false
+        "Comment": "Tschechoslowakei"
       },
       {
         "Text": "Reykjavik",
         "Correct": false,
-        "Comment": "Island",
-        "Revealed": false
+        "Comment": "Island"
       },
       {
         "Text": "Seoul",
         "Correct": true,
-        "Comment": "S\u00FCdkorea",
-        "Revealed": false
+        "Comment": "Südkorea"
       },
       {
         "Text": "Sydney",
         "Correct": true,
-        "Comment": "Australien",
-        "Revealed": false
+        "Comment": "Australien"
       },
       {
         "Text": "Tokyo",
         "Correct": true,
-        "Comment": "Japan",
-        "Revealed": false
+        "Comment": "Japan"
       },
       {
         "Text": "Warschau",
         "Correct": false,
-        "Comment": "Polen",
-        "Revealed": false
+        "Comment": "Polen"
       },
       {
         "Text": "Wien",
         "Correct": true,
-        "Comment": "\u00D6sterreich",
-        "Revealed": false
+        "Comment": "Österreich"
       }
     ]
   },
@@ -11838,98 +9982,82 @@
       {
         "Text": "Arbeiter im Weinberg",
         "Correct": false,
-        "Comment": "Mt 20, 1-6",
-        "Revealed": false
+        "Comment": "Mt 20, 1-6"
       },
       {
         "Text": "Barmherziger Samariter",
         "Correct": true,
-        "Comment": "Lk 10, 30-37",
-        "Revealed": false
+        "Comment": "Lk 10, 30-37"
       },
       {
         "Text": "Bittender Freund",
         "Correct": true,
-        "Comment": "Lk 11, 5-8",
-        "Revealed": false
+        "Comment": "Lk 11, 5-8"
       },
       {
         "Text": "Hausbau auf Sand/Fels",
         "Correct": true,
-        "Comment": "Lk 6, 47-49",
-        "Revealed": false
+        "Comment": "Lk 6, 47-49"
       },
       {
         "Text": "Reicher Kornbauer",
         "Correct": true,
-        "Comment": "Lk 12, 16-21",
-        "Revealed": false
+        "Comment": "Lk 12, 16-21"
       },
       {
         "Text": "Reicher Mann und armer Lazarus",
         "Correct": true,
-        "Comment": "Lk 16, 19-31",
-        "Revealed": false
+        "Comment": "Lk 16, 19-31"
       },
       {
-        "Text": "S\u00E4mann",
+        "Text": "Sämann",
         "Correct": true,
-        "Comment": "Lk 8, 5-8",
-        "Revealed": false
+        "Comment": "Lk 8, 5-8"
       },
       {
         "Text": "Sauerteig",
         "Correct": true,
-        "Comment": "Lk 13, 20f",
-        "Revealed": false
+        "Comment": "Lk 13, 20f"
       },
       {
         "Text": "Schalksknecht",
         "Correct": false,
-        "Comment": "Mt 18, 23-35",
-        "Revealed": false
+        "Comment": "Mt 18, 23-35"
       },
       {
         "Text": "Selbstwachsende Saat",
         "Correct": false,
-        "Comment": "Mk 4, 26-29",
-        "Revealed": false
+        "Comment": "Mk 4, 26-29"
       },
       {
         "Text": "Senfkorn",
         "Correct": true,
-        "Comment": "Lk 13, 18f",
-        "Revealed": false
+        "Comment": "Lk 13, 18f"
       },
       {
-        "Text": "Treuer und b\u00F6ser Knecht",
+        "Text": "Treuer und böser Knecht",
         "Correct": true,
-        "Comment": "Lk 12, 42-46",
-        "Revealed": false
+        "Comment": "Lk 12, 42-46"
       },
       {
         "Text": "Unehrlicher Verwalter",
         "Correct": true,
-        "Comment": "Lk 16, 1-8",
-        "Revealed": false
+        "Comment": "Lk 16, 1-8"
       },
       {
         "Text": "Unkraut unter dem Weizen",
         "Correct": false,
-        "Comment": "Mt 13, 24-30",
-        "Revealed": false
+        "Comment": "Mt 13, 24-30"
       },
       {
         "Text": "Verlorener Sohn",
         "Correct": true,
-        "Comment": "Lk 15, 11-32",
-        "Revealed": false
+        "Comment": "Lk 15, 11-32"
       },
       {
         "Text": "Verlorenes Schaf",
         "Correct": true,
-        "Comment": "Lk 15, 4-7",
-        "Revealed": false
+        "Comment": "Lk 15, 4-7"
       }
     ]
   },
@@ -11940,200 +10068,168 @@
       {
         "Text": "Alkmene",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Boskoop",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Elstar",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gala",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gloster",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Golden Delicious",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Goldparm\u00E4ne",
+        "Text": "Goldparmäne",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Graf Althans",
         "Correct": false,
-        "Comment": "Reneklode",
-        "Revealed": false
+        "Comment": "Reneklode"
       },
       {
         "Text": "Grafensteiner",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Granny Smith",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gute Luise",
         "Correct": false,
-        "Comment": "Birne",
-        "Revealed": false
+        "Comment": "Birne"
       },
       {
         "Text": "Havelgold",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Idared",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jonagold",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Roter Ellerst\u00E4tter",
+        "Text": "Roter Ellerstätter",
         "Correct": false,
-        "Comment": "Pfirsich",
-        "Revealed": false
+        "Comment": "Pfirsich"
       },
       {
         "Text": "Williams Christ",
         "Correct": false,
-        "Comment": "Birne",
-        "Revealed": false
+        "Comment": "Birne"
       }
     ]
   },
   {
-    "Text": "Wer geh\u00F6rt zu den 12 J\u00FCngern Jesu?",
+    "Text": "Wer gehört zu den 12 Jüngern Jesu?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Andreas",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Bartholom\u00E4us",
+        "Text": "Bartholomäus",
         "Correct": true,
-        "Comment": "oder Nathanael",
-        "Revealed": false
-      },
-      {
-        "Text": "Jakobus",
-        "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": "oder Nathanael"
       },
       {
         "Text": "Jakobus",
         "Correct": true,
-        "Comment": "Sohn des Alph\u00E4us",
-        "Revealed": false
+        "Comment": null
+      },
+      {
+        "Text": "Jakobus",
+        "Correct": true,
+        "Comment": "Sohn des Alphäus"
       },
       {
         "Text": "Johannes",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Judas",
         "Correct": true,
-        "Comment": "Bruder des Jakobus",
-        "Revealed": false
+        "Comment": "Bruder des Jakobus"
       },
       {
         "Text": "Judas",
         "Correct": true,
-        "Comment": "Judas Iskariot",
-        "Revealed": false
+        "Comment": "Judas Iskariot"
       },
       {
         "Text": "Lukas",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Markus",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Matth\u00E4us",
+        "Text": "Matthäus",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Paulus",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Petrus",
         "Correct": true,
-        "Comment": "Simon Petrus",
-        "Revealed": false
+        "Comment": "Simon Petrus"
       },
       {
         "Text": "Philippus",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Simon",
         "Correct": true,
-        "Comment": "genannt Zelotes",
-        "Revealed": false
+        "Comment": "genannt Zelotes"
       },
       {
         "Text": "Stephanus",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Thomas",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -12144,200 +10240,168 @@
       {
         "Text": "Ahija",
         "Correct": true,
-        "Comment": "1. K\u00F6nige 11, 29",
-        "Revealed": false
+        "Comment": "1. Könige 11, 29"
       },
       {
         "Text": "Asaf",
         "Correct": false,
-        "Comment": "ein Dichter",
-        "Revealed": false
+        "Comment": "ein Dichter"
       },
       {
         "Text": "Bileam",
         "Correct": true,
-        "Comment": "4. Mose 22,5",
-        "Revealed": false
+        "Comment": "4. Mose 22,5"
       },
       {
         "Text": "Datan",
         "Correct": false,
-        "Comment": "ber\u00FChmter Mann",
-        "Revealed": false
+        "Comment": "berühmter Mann"
       },
       {
         "Text": "Elia",
         "Correct": true,
-        "Comment": "1. K\u00F6nige 18,36",
-        "Revealed": false
+        "Comment": "1. Könige 18,36"
       },
       {
         "Text": "Gad",
         "Correct": true,
-        "Comment": "1. Samuel 22,5",
-        "Revealed": false
+        "Comment": "1. Samuel 22,5"
       },
       {
         "Text": "Hosea",
         "Correct": true,
-        "Comment": "Hosea 1,1",
-        "Revealed": false
+        "Comment": "Hosea 1,1"
       },
       {
         "Text": "Iddo",
         "Correct": true,
-        "Comment": "2. Chronik 13,22",
-        "Revealed": false
+        "Comment": "2. Chronik 13,22"
       },
       {
         "Text": "Jakob",
         "Correct": false,
-        "Comment": "ein Patriarch",
-        "Revealed": false
+        "Comment": "ein Patriarch"
       },
       {
-        "Text": "Johannes der T\u00E4ufer",
+        "Text": "Johannes der Täufer",
         "Correct": true,
-        "Comment": "Lukas 7,28",
-        "Revealed": false
+        "Comment": "Lukas 7,28"
       },
       {
         "Text": "Micha",
         "Correct": true,
-        "Comment": "Jeremia 26, 18",
-        "Revealed": false
+        "Comment": "Jeremia 26, 18"
       },
       {
         "Text": "Obed",
         "Correct": true,
-        "Comment": "2. Chronik 28,9",
-        "Revealed": false
+        "Comment": "2. Chronik 28,9"
       },
       {
         "Text": "Omri",
         "Correct": false,
-        "Comment": "ein K\u00F6nig",
-        "Revealed": false
+        "Comment": "ein König"
       },
       {
         "Text": "Sacharja",
         "Correct": true,
-        "Comment": "Sacharja 1,1",
-        "Revealed": false
+        "Comment": "Sacharja 1,1"
       },
       {
         "Text": "Samuel",
         "Correct": true,
-        "Comment": "1. Samuel 3,20",
-        "Revealed": false
+        "Comment": "1. Samuel 3,20"
       },
       {
         "Text": "Zefanja",
         "Correct": true,
-        "Comment": "Zefanja 1,1",
-        "Revealed": false
+        "Comment": "Zefanja 1,1"
       }
     ]
   },
   {
-    "Text": "St\u00E4dte in Sachsen",
+    "Text": "Städte in Sachsen",
     "Selected": false,
     "Answers": [
       {
         "Text": "Bautzen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bitterfeld",
         "Correct": false,
-        "Comment": "Sachsen-Anhalt",
-        "Revealed": false
+        "Comment": "Sachsen-Anhalt"
       },
       {
         "Text": "Chemnitz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cottbus",
         "Correct": false,
-        "Comment": "Brandenburg",
-        "Revealed": false
+        "Comment": "Brandenburg"
       },
       {
         "Text": "Dessau",
         "Correct": false,
-        "Comment": "Sachsen-Anhalt",
-        "Revealed": false
+        "Comment": "Sachsen-Anhalt"
       },
       {
-        "Text": "D\u00F6beln",
+        "Text": "Döbeln",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "G\u00F6rlitz",
+        "Text": "Görlitz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jena",
         "Correct": false,
-        "Comment": "Th\u00FCringen",
-        "Revealed": false
+        "Comment": "Thüringen"
       },
       {
         "Text": "Leipzig",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Mei\u00DFen",
+        "Text": "Meißen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pirna",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Plauen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Riesa",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Seifen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zittau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zwickau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -12348,506 +10412,426 @@
       {
         "Text": "ABS",
         "Correct": true,
-        "Comment": "Anti-Blockier-System",
-        "Revealed": false
+        "Comment": "Anti-Blockier-System"
       },
       {
         "Text": "Airbag",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "ASD",
         "Correct": true,
-        "Comment": "Automat. Sperr-Differential",
-        "Revealed": false
+        "Comment": "Automat. Sperr-Differential"
       },
       {
         "Text": "ASR",
         "Correct": true,
-        "Comment": "Antriebs-Schlupf-Regelung",
-        "Revealed": false
+        "Comment": "Antriebs-Schlupf-Regelung"
       },
       {
         "Text": "ATC",
         "Correct": false,
-        "Comment": "Air Traffic Controll",
-        "Revealed": false
+        "Comment": "Air Traffic Controll"
       },
       {
         "Text": "Dynamo",
         "Correct": false,
-        "Comment": "Fahrrad",
-        "Revealed": false
+        "Comment": "Fahrrad"
       },
       {
         "Text": "Federbeine",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Katalysator",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lambda Sonde",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Navigationssystem",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nockenwelle",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Querlenker",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Radar",
         "Correct": false,
-        "Comment": "Schiff/Flugzeug",
-        "Revealed": false
+        "Comment": "Schiff/Flugzeug"
       },
       {
         "Text": "Rotor",
         "Correct": false,
-        "Comment": "Hubschrauber",
-        "Revealed": false
+        "Comment": "Hubschrauber"
       },
       {
         "Text": "Traktionskontrolle",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zylinder",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche Bauwerke sind h\u00F6her als der K\u00F6lner Dom (160m)?",
+    "Text": "Welche Bauwerke sind höher als der Kölner Dom (160m)?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Cheopspyramide",
         "Correct": false,
-        "Comment": "137m",
-        "Revealed": false
+        "Comment": "137m"
       },
       {
         "Text": "CN Tower Toronto",
         "Correct": true,
-        "Comment": "559m",
-        "Revealed": false
+        "Comment": "559m"
       },
       {
         "Text": "Eiffelturm",
         "Correct": true,
-        "Comment": "300m",
-        "Revealed": false
+        "Comment": "300m"
       },
       {
         "Text": "Empire State Building",
         "Correct": true,
-        "Comment": "448m",
-        "Revealed": false
+        "Comment": "448m"
       },
       {
         "Text": "Fernsehturm Alexanderplatz",
         "Correct": true,
-        "Comment": "362m",
-        "Revealed": false
+        "Comment": "362m"
       },
       {
-        "Text": "Fernsehturm M\u00FCnchen",
+        "Text": "Fernsehturm München",
         "Correct": true,
-        "Comment": "290m",
-        "Revealed": false
+        "Comment": "290m"
       },
       {
         "Text": "Golden Gate Bridge",
         "Correct": true,
-        "Comment": "259m",
-        "Revealed": false
+        "Comment": "259m"
       },
       {
         "Text": "Hamburger Michel",
         "Correct": false,
-        "Comment": "133m",
-        "Revealed": false
+        "Comment": "133m"
       },
       {
         "Text": "Hooverdamm (Staumauer)",
         "Correct": true,
-        "Comment": "224m",
-        "Revealed": false
+        "Comment": "224m"
       },
       {
         "Text": "Hotel Burj Al Arab",
         "Correct": true,
-        "Comment": "321m",
-        "Revealed": false
+        "Comment": "321m"
       },
       {
         "Text": "Petersdom Rom",
         "Correct": false,
-        "Comment": "138m",
-        "Revealed": false
+        "Comment": "138m"
       },
       {
         "Text": "Petronas Towers",
         "Correct": true,
-        "Comment": "452m",
-        "Revealed": false
+        "Comment": "452m"
       },
       {
         "Text": "Schiefer Turm Pisa",
         "Correct": false,
-        "Comment": "54m",
-        "Revealed": false
+        "Comment": "54m"
       },
       {
         "Text": "Sears Tower",
         "Correct": true,
-        "Comment": "443m",
-        "Revealed": false
+        "Comment": "443m"
       },
       {
         "Text": "Stuttgarter Fernsehturm",
         "Correct": true,
-        "Comment": "214m",
-        "Revealed": false
+        "Comment": "214m"
       },
       {
-        "Text": "Ulmer M\u00FCnster",
+        "Text": "Ulmer Münster",
         "Correct": true,
-        "Comment": "162m",
-        "Revealed": false
+        "Comment": "162m"
       }
     ]
   },
   {
-    "Text": "Welches technische Ger\u00E4t wurde vor 1769 (Dampfmaschine) erfunden?",
+    "Text": "Welches technische Gerät wurde vor 1769 (Dampfmaschine) erfunden?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Alkohol-thermometer",
         "Correct": true,
-        "Comment": "1730",
-        "Revealed": false
+        "Comment": "1730"
       },
       {
         "Text": "Blitzableiter",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Buchdruck",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Dampfkochtopf \u0026 Sicherheitsventil",
+        "Text": "Dampfkochtopf & Sicherheitsventil",
         "Correct": true,
-        "Comment": "1664",
-        "Revealed": false
+        "Comment": "1664"
       },
       {
         "Text": "Dampfschiff",
         "Correct": false,
-        "Comment": "1798",
-        "Revealed": false
+        "Comment": "1798"
       },
       {
         "Text": "Fernrohr",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gewindeschneide-maschine",
         "Correct": true,
-        "Comment": "1568",
-        "Revealed": false
+        "Comment": "1568"
       },
       {
-        "Text": "Hei\u00DFluftballon",
+        "Text": "Heißluftballon",
         "Correct": false,
-        "Comment": "1782",
-        "Revealed": false
+        "Comment": "1782"
       },
       {
         "Text": "Kolbenluftpumpe",
         "Correct": true,
-        "Comment": "1650",
-        "Revealed": false
+        "Comment": "1650"
       },
       {
         "Text": "mechanischer Webstuhl",
         "Correct": false,
-        "Comment": "1785",
-        "Revealed": false
+        "Comment": "1785"
       },
       {
         "Text": "Mikroskop",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "N\u00E4hmaschine",
+        "Text": "Nähmaschine",
         "Correct": true,
-        "Comment": "1755",
-        "Revealed": false
+        "Comment": "1755"
       },
       {
         "Text": "Quecksilber-barometer",
         "Correct": true,
-        "Comment": "1643",
-        "Revealed": false
+        "Comment": "1643"
       },
       {
         "Text": "Quecksilber-thermometer",
         "Correct": true,
-        "Comment": "1718",
-        "Revealed": false
+        "Comment": "1718"
       },
       {
         "Text": "Rechenmaschine",
         "Correct": true,
-        "Comment": "1642",
-        "Revealed": false
+        "Comment": "1642"
       },
       {
         "Text": "Telegraf",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "S\u00E4nger/-innen die den Grand Prix Eurovision de la Chanson gewannen.",
+    "Text": "Sänger/-innen die den Grand Prix Eurovision de la Chanson gewannen.",
     "Selected": false,
     "Answers": [
       {
         "Text": "Abba",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Al Bano \u0026 Romina Power",
+        "Text": "Al Bano & Romina Power",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Brotherhood of Man",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Celine Dion",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cliff Richard",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Corry Brokken",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gilbert Becaud",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Johnny Logon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Karel Gott",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lys Assia",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nicole",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Olsson Brothers",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sandie Shaw",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Toto Cutugno",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Udo J\u00FCrgens",
+        "Text": "Udo Jürgens",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Vicky Leandros",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Filme bei den Alfred Hitchcock Regie f\u00FChrte",
+    "Text": "Filme bei den Alfred Hitchcock Regie führte",
     "Selected": false,
     "Answers": [
       {
         "Text": "39 Stufen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bei Anruf Mord",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Das Fenster zum Hof",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Auslands-korrespondent",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der dritte Mann",
         "Correct": false,
-        "Comment": "Carol Reed",
-        "Revealed": false
+        "Comment": "Carol Reed"
       },
       {
         "Text": "Der Hexer",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Der Mann der zuviel wu\u00DFte",
+        "Text": "Der Mann der zuviel wußte",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der unsichtbare Dritte",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Die V\u00F6gel",
+        "Text": "Die Vögel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Frenzy",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Marnie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Psycho",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Topas",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tote schlafen fest",
         "Correct": false,
-        "Comment": "Howard Hawks",
-        "Revealed": false
+        "Comment": "Howard Hawks"
       },
       {
-        "Text": "\u00DCber den D\u00E4chern von Nizza",
+        "Text": "Über den Dächern von Nizza",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Vertigo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -12858,98 +10842,82 @@
       {
         "Text": "Alligator",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Blindschleiche",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Cham\u00E4leon",
+        "Text": "Chamäleon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Flugdrache",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gilatier",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Klapperschlange",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Krokodil",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Leguan",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Maulwurf",
         "Correct": false,
-        "Comment": "S\u00E4ugetier",
-        "Revealed": false
+        "Comment": "Säugetier"
       },
       {
         "Text": "Meerechse",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Natter",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Regenwurm",
         "Correct": false,
-        "Comment": "Wirbellose",
-        "Revealed": false
+        "Comment": "Wirbellose"
       },
       {
         "Text": "Salamander",
         "Correct": false,
-        "Comment": "Amphibien",
-        "Revealed": false
+        "Comment": "Amphibien"
       },
       {
-        "Text": "Schildkr\u00F6te",
+        "Text": "Schildkröte",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schnabeltier",
         "Correct": false,
-        "Comment": "S\u00E4ugetier",
-        "Revealed": false
+        "Comment": "Säugetier"
       },
       {
         "Text": "Waran",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -12960,302 +10928,254 @@
       {
         "Text": "Bayer 04 Leverkusen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dresdner SC",
         "Correct": true,
-        "Comment": "1940, 1941",
-        "Revealed": false
+        "Comment": "1940, 1941"
       },
       {
-        "Text": "Fortuna D\u00FCsseldorf",
+        "Text": "Fortuna Düsseldorf",
         "Correct": true,
-        "Comment": "1979, 1980",
-        "Revealed": false
+        "Comment": "1979, 1980"
       },
       {
         "Text": "Hertha BSC Berlin",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Karlsruher SC",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "KFC Uerdingen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kickers Offenbach",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "MSV Duisburg",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rapid Wien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Rot-Wei\u00DF Essen",
+        "Text": "Rot-Weiß Essen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Schwarz-Wei\u00DF Essen",
+        "Text": "Schwarz-Weiß Essen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "SV Hannover 96",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "SV Waldhof Mannheim",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "TSV 1860 M\u00FCnchen",
+        "Text": "TSV 1860 München",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "VfB Leipzig",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "VfL Bochum",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "In welchen St\u00E4dten fanden Olympische Sommerspiele Stadt?",
+    "Text": "In welchen Städten fanden Olympische Sommerspiele Stadt?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Amsterdam",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Antwerpen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Barcelona",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Buenos Aires",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Helsinki",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kopenhagen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "London",
         "Correct": true,
-        "Comment": "1908, 1948",
-        "Revealed": false
+        "Comment": "1908, 1948"
       },
       {
         "Text": "Melbourne",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mexiko City",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Montreal",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "New York",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rom",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "St. Louis",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Stockholm",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tokio",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche St\u00E4dte liegen in Mecklenburg-Vorpommern?",
+    "Text": "Welche Städte liegen in Mecklenburg-Vorpommern?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Anklam",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bad Doberan",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Greifswald",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "G\u00FCstrow",
+        "Text": "Güstrow",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Neubrandenburg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Neustrelitz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Oranienburg",
         "Correct": false,
-        "Comment": "Brandenburg",
-        "Revealed": false
+        "Comment": "Brandenburg"
       },
       {
         "Text": "Parchim",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Prenzlau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ratzeburg",
         "Correct": false,
-        "Comment": "Schleswig-Holstein",
-        "Revealed": false
+        "Comment": "Schleswig-Holstein"
       },
       {
         "Text": "Rostock",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schwerin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Stendal",
         "Correct": false,
-        "Comment": "Sachsen-Anhalt",
-        "Revealed": false
+        "Comment": "Sachsen-Anhalt"
       },
       {
         "Text": "Stettin",
         "Correct": false,
-        "Comment": "Polen",
-        "Revealed": false
+        "Comment": "Polen"
       },
       {
         "Text": "Stralsund",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wismar",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -13266,98 +11186,82 @@
       {
         "Text": "Berchtesgaden",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Calgary",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Charmonix",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Cortina d\u0060Ampezzo",
+        "Text": "Cortina d`Ampezzo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Denver",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Grenoble",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Grindelwald",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Innsbruck",
         "Correct": true,
-        "Comment": "1964, 1976",
-        "Revealed": false
+        "Comment": "1964, 1976"
       },
       {
         "Text": "Lahti",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lillehammer",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nagano",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Oslo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sapporro",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sarajewo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Squaw Valley",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "St. Moritz",
         "Correct": true,
-        "Comment": "1928, 1948",
-        "Revealed": false
+        "Comment": "1928, 1948"
       }
     ]
   },
@@ -13368,98 +11272,82 @@
       {
         "Text": "Stickstoff",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Helium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jod",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Xenon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Argon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Chlor",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kohlenstoff",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schwefel",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wasserstoff",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sauerstoff",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Oganesson",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Radon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Fluor",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Neon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Brom",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Krypton",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -13470,200 +11358,168 @@
       {
         "Text": "34",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "11",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "5",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "8",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "47",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "48",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "41",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "13",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "46",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "23",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "42",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "7",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "19",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "3",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "29",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "40",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche europ\u00E4ischen Staaten haben keinen Zugang zum Meer?",
+    "Text": "Welche europäischen Staaten haben keinen Zugang zum Meer?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Luxemburg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Montenegro",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Albanien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Belgien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Andorra",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Serbien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Griechenland",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Finnland",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Slowakei",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Slowenien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Belarus",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "\u00D6sterreich",
+        "Text": "Österreich",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Moldau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kroatien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kosovo",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lettland",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -13674,98 +11530,82 @@
       {
         "Text": "Der Steppenwolf",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Iphigenie auf Tauris",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Wie es euch gef\u00E4llt",
+        "Text": "Wie es euch gefällt",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der zerbrochne Krug",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Viel L\u00E4rm um nichts",
+        "Text": "Viel Lärm um nichts",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Sturm",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Othello",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Die R\u00E4uber",
+        "Text": "Die Räuber",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Leonce und Lena",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hamlet",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Besuch der alten Dame",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Faust",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Julius C\u00E4sar",
+        "Text": "Julius Cäsar",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wilhelm Tell",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Macbeth",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ein Sommernachtstraum",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -13776,200 +11616,168 @@
       {
         "Text": "Neon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Methan",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ethanol",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ammoniak",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Schwefels\u00E4ure",
+        "Text": "Schwefelsäure",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Argon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wasser",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zucker",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Platin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gold",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kohlendioxid",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Uran",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kalk",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zink",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Calcium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kalium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche St\u00E4dte sind Hauptst\u00E4dte von EU-L\u00E4ndern?",
+    "Text": "Welche Städte sind Hauptstädte von EU-Ländern?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Salzburg",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Warschau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Vilnius",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mailand",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Athen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "M\u00FCnchen",
+        "Text": "München",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Krakau",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Riga",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bremen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Antwerpen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Budapest",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Szczecin",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Helsinki",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tallinn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Porto",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Br\u00FCssel",
+        "Text": "Brüssel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -13980,98 +11788,82 @@
       {
         "Text": "Laravel",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Julia",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "NumPy",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ruby",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "C",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Unity",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Swift",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Java",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Django",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "TensorFlow",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Go",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "C#",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "React",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kotlin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Spring",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Flask",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -14082,98 +11874,82 @@
       {
         "Text": "Eris",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mars",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Saturn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Europa",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Venus",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kallisto",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Io",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Titan",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ceres",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Jupiter",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Uranus",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ganymed",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Merkur",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pluto",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Neptun",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Erde",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -14184,98 +11960,82 @@
       {
         "Text": "Alveole",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Axon",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Femur",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Radius",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tibia",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Neuron",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sternum",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mandibula",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Patella",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dendrit",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sarkomer",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Scapula",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Insulin",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Retina",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nephron",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Clavicula",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -14286,86 +12046,72 @@
       {
         "Text": "OR",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "AND",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "FILTER",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "MAP",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "XNOR",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "TRANSPOSE",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "NOT",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "PLOT",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "GROUP BY",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "REDUCE",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "XOR",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "JOIN",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "NOR",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "NAND",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -14376,92 +12122,77 @@
       {
         "Text": "Francium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Silicium",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Titan",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Blei",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Aluminium",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zinn",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Chrom",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Natrium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lithium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Magnesium",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "C\u00E4sium",
+        "Text": "Cäsium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rubidium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kalium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Barium",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Calcium",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -14472,344 +12203,290 @@
       {
         "Text": "Sauerstoff",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schwefel",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Neon",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tenness",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Selen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Argon",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kohlenstoff",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Astat",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Fluor",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Chlor",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Stickstoff",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Iod",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Brom",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche Tiere sind S\u00E4ugetiere?",
+    "Text": "Welche Tiere sind Säugetiere?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Krokodil",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Biene",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "K\u00E4nguru",
+        "Text": "Känguru",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Orang-Utan",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Giraffe",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Forelle",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Krake",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Fledermaus",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Faultier",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Robbe",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Adler",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wal",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Frosch",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Delfin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hummer",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche L\u00E4nder liegen vollst\u00E4ndig in S\u00FCdamerika?",
+    "Text": "Welche Länder liegen vollständig in Südamerika?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Guatemala",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Peru",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bolivien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Uruguay",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ecuador",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Guyana",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Argentinien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Belize",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mexiko",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Costa Rica",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Paraguay",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Chile",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Honduras",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Panama",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nicaragua",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche sind Prim\u00E4rfarben der additiven Farbmischung?",
+    "Text": "Welche sind Primärfarben der additiven Farbmischung?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "Wei\u00DF",
+        "Text": "Weiß",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Magenta",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Orange",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rot",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cyan",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pink",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Blau",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lila",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Gr\u00FCn",
+        "Text": "Grün",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gelb",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schwarz",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -14820,98 +12497,82 @@
       {
         "Text": "1",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "100",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "36",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "25",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "6",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "2",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "12",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "49",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "16",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "8",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "5",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "48",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "81",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "3",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "9",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "24",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -14922,248 +12583,209 @@
       {
         "Text": "Drachen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rechteck",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sechseck",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Trapez",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Parallelogramm",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "F\u00FCnfeck",
+        "Text": "Fünfeck",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Raute",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kreis",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dreieck",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ellipse",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Quadrat",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche sind deutsche Bundesl\u00E4nder?",
+    "Text": "Welche sind deutsche Bundesländer?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Berlin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lothringen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lombardei",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bremen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Brandenburg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Flandern",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "K\u00E4rnten",
+        "Text": "Kärnten",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Burgund",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bayern",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Saarland",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Niedersachsen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tirol",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mecklenburg-Vorpommern",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Elsass",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Baden-W\u00FCrttemberg",
+        "Text": "Baden-Württemberg",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche Fl\u00FCsse m\u00FCnden in die Nordsee?",
+    "Text": "Welche Flüsse münden in die Nordsee?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Po",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Donau",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Weser",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tiber",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Seine",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Elbe",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rhone",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dnepr",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schelde",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ems",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Weichsel",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Themse",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rhein",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -15174,86 +12796,72 @@
       {
         "Text": "Erzgebirge",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Harz",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Fichtelgebirge",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Pyren\u00E4en",
+        "Text": "Pyrenäen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Spessart",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bayerischer Wald",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Balkan",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Anden",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Karpaten",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Himalaya",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Hunsr\u00FCck",
+        "Text": "Hunsrück",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Eifel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Th\u00FCringer Wald",
+        "Text": "Thüringer Wald",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Apennin",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -15264,98 +12872,82 @@
       {
         "Text": "Neuseeland",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Frankreich",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Deutschland",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Barbados",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "D\u00E4nemark",
+        "Text": "Dänemark",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Philippinen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Spanien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mexiko",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Bahamas",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "T\u00FCrkei",
+        "Text": "Türkei",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Japan",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Madagaskar",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kanada",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "USA",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Indonesien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sri Lanka",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -15366,98 +12958,82 @@
       {
         "Text": "Unity",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "MySQL",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Photoshop",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Node.js",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "NetBSD",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Word",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "ChromeOS",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "React",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "OpenBSD",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Windows",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "iOS",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "FreeBSD",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Linux",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "PostgreSQL",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "macOS",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Qt",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -15468,176 +13044,148 @@
       {
         "Text": "Elasticsearch",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "SQLite",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cassandra",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Firebase",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "MySQL",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Microsoft SQL Server",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "MongoDB",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Neo4j",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Oracle Database",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Redis",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "PostgreSQL",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "MariaDB",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche HTTP-Statuscodes stehen f\u00FCr Fehler?",
+    "Text": "Welche HTTP-Statuscodes stehen für Fehler?",
     "Selected": false,
     "Answers": [
       {
         "Text": "403",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "501",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "302",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "408",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "200",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "202",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "400",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "307",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "301",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "304",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "502",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "201",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "410",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "204",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "405",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "404",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -15648,74 +13196,62 @@
       {
         "Text": "7Z",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "PNG",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "JPEG",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "ZIP",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "GZIP",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "RAR",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "OGG Vorbis",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "HEIC",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "FLAC",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "MP3",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "ALAC",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "AAC",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -15726,152 +13262,128 @@
       {
         "Text": "Groovy",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Rust",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Swift",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kotlin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "C#",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Java",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Scala",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Clojure",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Haskell",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Objective-C",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Go",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche Vitamine sind fettl\u00F6slich?",
+    "Text": "Welche Vitamine sind fettlöslich?",
     "Selected": false,
     "Answers": [
       {
         "Text": "B1",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "B9",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "K",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "B2",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "B5",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "B12",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "D",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "C",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "B3",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "E",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "A",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "B7",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "B6",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -15882,56 +13394,47 @@
       {
         "Text": "Endoplasmatisches Retikulum",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zellsaftvakuole",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Golgi-Apparat",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lysosomen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zellwand",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Chloroplasten",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zentriolen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mitochondrien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ribosomen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -15942,50 +13445,42 @@
       {
         "Text": "Adrenalin",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Testosteron",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Thyroxin",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Somatostatin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "\u00D6strogen",
+        "Text": "Östrogen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Insulin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Glukagon",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cortisol",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -15996,50 +13491,42 @@
       {
         "Text": "Zygoten",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Spirillen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Vibrionen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Alveolen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Myofibrillen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kokken",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Neuriten",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "St\u00E4bchen",
+        "Text": "Stäbchen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -16050,158 +13537,134 @@
       {
         "Text": "D",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "E",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "0",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "A",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "F",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "AB",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "C",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "B",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche Komponisten geh\u00F6ren zur Wiener Klassik?",
+    "Text": "Welche Komponisten gehören zur Wiener Klassik?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Richard Wagner",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ludwig van Beethoven",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Johann Sebastian Bach",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Joseph Haydn",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Felix Mendelssohn",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Johannes Brahms",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Franz Schubert",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Wolfgang Amadeus Mozart",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche Gem\u00E4lde stammen von Leonardo da Vinci?",
+    "Text": "Welche Gemälde stammen von Leonardo da Vinci?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Sternennacht",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mona Lisa",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Das Abendmahl",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dame mit Hermelin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Der Schrei",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Die Nachtwache",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Verk\u00FCndigung",
+        "Text": "Verkündigung",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Guernica",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -16212,128 +13675,108 @@
       {
         "Text": "Roman",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Essay",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Limerick",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ode",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Elegie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ballade",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sonett",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Trag\u00F6die",
+        "Text": "Tragödie",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Haiku",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Novelle",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Fabel",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche Instrumente geh\u00F6ren zur Streicherfamilie?",
+    "Text": "Welche Instrumente gehören zur Streicherfamilie?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "Fl\u00F6te",
+        "Text": "Flöte",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Klavier",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Violine",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Trompete",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kontrabass",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Posaune",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Cello",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Viola",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Klarinette",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -16342,250 +13785,211 @@
     "Selected": false,
     "Answers": [
       {
-        "Text": "D\u00E4nisch",
+        "Text": "Dänisch",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Portugiesisch",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Englisch",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Okzitanisch",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tschechisch",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Rum\u00E4nisch",
+        "Text": "Rumänisch",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Deutsch",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schwedisch",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Spanisch",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Niederl\u00E4ndisch",
+        "Text": "Niederländisch",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Katalanisch",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Galicisch",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Polnisch",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Italienisch",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "Franz\u00F6sisch",
+        "Text": "Französisch",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche Gr\u00F6\u00DFen sind SI-Basiseinheiten?",
+    "Text": "Welche Größen sind SI-Basiseinheiten?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Kilogramm",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Newton",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Hertz",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mol",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lux",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Volt",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Sekunde",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ampere",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Candela",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Joule",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Pascal",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Meter",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kelvin",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Watt",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Lumen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ohm",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche Kr\u00E4fte sind Grundkr\u00E4fte der Physik?",
+    "Text": "Welche Kräfte sind Grundkräfte der Physik?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Elektromagnetismus",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Federkraft",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zentrifugalkraft",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Schwache Wechselwirkung",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Reibung",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Auftrieb",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Gravitation",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Starke Wechselwirkung",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -16596,62 +14000,52 @@
       {
         "Text": "Druck",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Strahlungsenergie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Geschwindigkeit",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kernenergie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "kinetische Energie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Temperatur",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "potentielle Energie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "thermische Energie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "elektrische Energie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "chemische Energie",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -16662,140 +14056,118 @@
       {
         "Text": "Aluminium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Magnesium",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Chrom",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Eisen",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kohlenstofffaser",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Glas",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Quarz",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zink",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Keramik",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nickel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Quecksilber",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Kupfer",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Polyethylen",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche sind platonische K\u00F6rper?",
+    "Text": "Welche sind platonische Körper?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Kegel",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
-        "Text": "W\u00FCrfel",
+        "Text": "Würfel",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Tetraeder",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Zylinder",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Dodekaeder",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Oktaeder",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Ikosaeder",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "beliebige Pyramide",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Prisma",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
@@ -16804,178 +14176,150 @@
     "Selected": false,
     "Answers": [
       {
-        "Text": "S\u00FCdamerika",
+        "Text": "Südamerika",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Eurasien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Nordamerika",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Atlantis",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Europa",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Arabische Halbinsel",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Antarktika",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Asien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Australien/Ozeanien",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Afrika",
         "Correct": true,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Skandinavien",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       },
       {
         "Text": "Mittelamerika",
         "Correct": false,
-        "Comment": null,
-        "Revealed": false
+        "Comment": null
       }
     ]
   },
   {
-    "Text": "Welche europ\u00E4ischen L\u00E4nder sind Binnenstaaten (kein Zugang zum Meer)?",
+    "Text": "Welche europäischen Länder sind Binnenstaaten (kein Zugang zum Meer)?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Albanien",
         "Correct": false,
-        "Comment": "Adria-/Ionische K\u00FCste",
-        "Revealed": false
+        "Comment": "Adria-/Ionische Küste"
       },
       {
         "Text": "Tschechien",
         "Correct": true,
-        "Comment": "Mitteleuropa; kein Meer",
-        "Revealed": false
+        "Comment": "Mitteleuropa; kein Meer"
       },
       {
         "Text": "Serbien",
         "Correct": true,
-        "Comment": "Balkan; Donau statt Meer",
-        "Revealed": false
+        "Comment": "Balkan; Donau statt Meer"
       },
       {
         "Text": "Andorra",
         "Correct": true,
-        "Comment": "Pyren\u00E4en; zwischen Spanien/Frankreich",
-        "Revealed": false
+        "Comment": "Pyrenäen; zwischen Spanien/Frankreich"
       },
       {
         "Text": "Luxemburg",
         "Correct": true,
-        "Comment": "Westeuropa; kein Meer",
-        "Revealed": false
+        "Comment": "Westeuropa; kein Meer"
       },
       {
         "Text": "Slowakei",
         "Correct": true,
-        "Comment": "Mitteleuropa; kein Meer",
-        "Revealed": false
+        "Comment": "Mitteleuropa; kein Meer"
       },
       {
         "Text": "Moldau (Moldova)",
         "Correct": true,
-        "Comment": "Zwischen Rum\u00E4nien/Ukraine",
-        "Revealed": false
+        "Comment": "Zwischen Rumänien/Ukraine"
       },
       {
-        "Text": "\u00D6sterreich",
+        "Text": "Österreich",
         "Correct": true,
-        "Comment": "Binnenstaat seit 1918",
-        "Revealed": false
+        "Comment": "Binnenstaat seit 1918"
       },
       {
         "Text": "Vatikanstadt",
         "Correct": true,
-        "Comment": "Enklave in Rom",
-        "Revealed": false
+        "Comment": "Enklave in Rom"
       },
       {
         "Text": "Nordmazedonien",
         "Correct": true,
-        "Comment": "Balkan; kein Meer",
-        "Revealed": false
+        "Comment": "Balkan; kein Meer"
       },
       {
         "Text": "Belarus",
         "Correct": true,
-        "Comment": "Osteuropa; kein Meer",
-        "Revealed": false
+        "Comment": "Osteuropa; kein Meer"
       },
       {
         "Text": "San Marino",
         "Correct": true,
-        "Comment": "Enklave in Italien",
-        "Revealed": false
+        "Comment": "Enklave in Italien"
       },
       {
         "Text": "Ungarn",
         "Correct": true,
-        "Comment": "Karpatenbecken; Balaton \u2260 Meer",
-        "Revealed": false
+        "Comment": "Karpatenbecken; Balaton ≠ Meer"
       },
       {
         "Text": "Liechtenstein",
         "Correct": true,
-        "Comment": "Alpen; zwischen CH/AT",
-        "Revealed": false
+        "Comment": "Alpen; zwischen CH/AT"
       },
       {
         "Text": "Schweiz",
         "Correct": true,
-        "Comment": "Alpen; Binnenstaat",
-        "Revealed": false
+        "Comment": "Alpen; Binnenstaat"
       },
       {
         "Text": "Bosnien und Herzegowina",
         "Correct": false,
-        "Comment": "K\u00FCstenstreifen bei Neum (Adria)",
-        "Revealed": false
+        "Comment": "Küstenstreifen bei Neum (Adria)"
       }
     ]
   },
@@ -16986,302 +14330,254 @@
       {
         "Text": "Americium",
         "Correct": true,
-        "Comment": "1944 (Seaborg u. a.)",
-        "Revealed": false
+        "Comment": "1944 (Seaborg u. a.)"
       },
       {
         "Text": "Mendelevium",
         "Correct": true,
-        "Comment": "1955 (Ghiorso u. a.)",
-        "Revealed": false
+        "Comment": "1955 (Ghiorso u. a.)"
       },
       {
         "Text": "Rhenium",
         "Correct": true,
-        "Comment": "1925 (Noddack u. a.)",
-        "Revealed": false
+        "Comment": "1925 (Noddack u. a.)"
       },
       {
         "Text": "Astat",
         "Correct": true,
-        "Comment": "1940 (Corson/MacKenzie/Segr\u00E8)",
-        "Revealed": false
+        "Comment": "1940 (Corson/MacKenzie/Segrè)"
       },
       {
         "Text": "Nobelium",
         "Correct": true,
-        "Comment": "1957\u201359 (Dubna/Berkeley)",
-        "Revealed": false
+        "Comment": "1957–59 (Dubna/Berkeley)"
       },
       {
         "Text": "Fermium",
         "Correct": true,
-        "Comment": "1952 (Ivy Mike-Debris)",
-        "Revealed": false
+        "Comment": "1952 (Ivy Mike-Debris)"
       },
       {
         "Text": "Einsteinium",
         "Correct": true,
-        "Comment": "1952 (Ivy Mike-Debris)",
-        "Revealed": false
+        "Comment": "1952 (Ivy Mike-Debris)"
       },
       {
         "Text": "Berkelium",
         "Correct": true,
-        "Comment": "1949 (Thompson u. a.)",
-        "Revealed": false
+        "Comment": "1949 (Thompson u. a.)"
       },
       {
         "Text": "Plutonium",
         "Correct": true,
-        "Comment": "1940 (Seaborg u. a.)",
-        "Revealed": false
+        "Comment": "1940 (Seaborg u. a.)"
       },
       {
         "Text": "Californium",
         "Correct": true,
-        "Comment": "1950 (Thompson u. a.)",
-        "Revealed": false
+        "Comment": "1950 (Thompson u. a.)"
       },
       {
         "Text": "Technetium",
         "Correct": true,
-        "Comment": "1937 (Perrier/Segr\u00E8)",
-        "Revealed": false
+        "Comment": "1937 (Perrier/Segrè)"
       },
       {
         "Text": "Francium",
         "Correct": true,
-        "Comment": "1939 (Perey)",
-        "Revealed": false
+        "Comment": "1939 (Perey)"
       },
       {
         "Text": "Astat",
         "Correct": true,
-        "Comment": "1940 (Corson/MacKenzie/Segr\u00E8)",
-        "Revealed": false
+        "Comment": "1940 (Corson/MacKenzie/Segrè)"
       },
       {
         "Text": "Neptunium",
         "Correct": true,
-        "Comment": "1940 (McMillan/Abelson)",
-        "Revealed": false
+        "Comment": "1940 (McMillan/Abelson)"
       },
       {
         "Text": "Curium",
         "Correct": true,
-        "Comment": "1944 (Seaborg u. a.)",
-        "Revealed": false
+        "Comment": "1944 (Seaborg u. a.)"
       },
       {
         "Text": "Lawrencium",
         "Correct": true,
-        "Comment": "1961 (Ghiorso u. a.)",
-        "Revealed": false
+        "Comment": "1961 (Ghiorso u. a.)"
       }
     ]
   },
   {
-    "Text": "Welche Komponisten waren Zeitgenossen von Mozart (1756\u20131791)?",
+    "Text": "Welche Komponisten waren Zeitgenossen von Mozart (1756–1791)?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Giovanni Paisiello",
         "Correct": true,
-        "Comment": "1740\u20131816",
-        "Revealed": false
+        "Comment": "1740–1816"
       },
       {
         "Text": "Johannes Brahms",
         "Correct": false,
-        "Comment": "1833\u20131897 (sp\u00E4tromantisch)",
-        "Revealed": false
+        "Comment": "1833–1897 (spätromantisch)"
       },
       {
         "Text": "Gustav Mahler",
         "Correct": false,
-        "Comment": "1860\u20131911 (sp\u00E4tromantisch)",
-        "Revealed": false
+        "Comment": "1860–1911 (spätromantisch)"
       },
       {
         "Text": "Michael Haydn",
         "Correct": true,
-        "Comment": "1737\u20131806",
-        "Revealed": false
+        "Comment": "1737–1806"
       },
       {
         "Text": "Christoph Willibald Gluck",
         "Correct": true,
-        "Comment": "1714\u20131787",
-        "Revealed": false
+        "Comment": "1714–1787"
       },
       {
         "Text": "Johann Nepomuk Hummel",
         "Correct": true,
-        "Comment": "1778\u20131837",
-        "Revealed": false
+        "Comment": "1778–1837"
       },
       {
         "Text": "Richard Wagner",
         "Correct": false,
-        "Comment": "1813\u20131883 (sp\u00E4ter)",
-        "Revealed": false
+        "Comment": "1813–1883 (später)"
       },
       {
         "Text": "Ludwig van Beethoven",
         "Correct": true,
-        "Comment": "1770\u20131827",
-        "Revealed": false
+        "Comment": "1770–1827"
       },
       {
         "Text": "Carl Philipp Emanuel Bach",
         "Correct": true,
-        "Comment": "1714\u20131788",
-        "Revealed": false
+        "Comment": "1714–1788"
       },
       {
         "Text": "Carl Ditters von Dittersdorf",
         "Correct": true,
-        "Comment": "1739\u20131799",
-        "Revealed": false
+        "Comment": "1739–1799"
       },
       {
         "Text": "Joseph Haydn",
         "Correct": true,
-        "Comment": "1732\u20131809",
-        "Revealed": false
+        "Comment": "1732–1809"
       },
       {
         "Text": "Luigi Boccherini",
         "Correct": true,
-        "Comment": "1743\u20131805",
-        "Revealed": false
+        "Comment": "1743–1805"
       },
       {
         "Text": "Muzio Clementi",
         "Correct": true,
-        "Comment": "1752\u20131832",
-        "Revealed": false
+        "Comment": "1752–1832"
       },
       {
-        "Text": "Fr\u00E9d\u00E9ric Chopin",
+        "Text": "Frédéric Chopin",
         "Correct": false,
-        "Comment": "1810\u20131849 (Romantik)",
-        "Revealed": false
+        "Comment": "1810–1849 (Romantik)"
       },
       {
         "Text": "Franz Schubert",
         "Correct": false,
-        "Comment": "1797\u20131828 (nach Mozart)",
-        "Revealed": false
+        "Comment": "1797–1828 (nach Mozart)"
       },
       {
         "Text": "Antonio Salieri",
         "Correct": true,
-        "Comment": "1750\u20131825",
-        "Revealed": false
+        "Comment": "1750–1825"
       }
     ]
   },
   {
-    "Text": "Welche W\u00F6rter im Deutschen sind Lehnw\u00F6rter aus dem Franz\u00F6sischen?",
+    "Text": "Welche Wörter im Deutschen sind Lehnwörter aus dem Französischen?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Friseur",
         "Correct": true,
-        "Comment": "frz. friseur",
-        "Revealed": false
+        "Comment": "frz. friseur"
       },
       {
         "Text": "Boulevard",
         "Correct": true,
-        "Comment": "frz. boulevard",
-        "Revealed": false
+        "Comment": "frz. boulevard"
       },
       {
         "Text": "Parfum",
         "Correct": true,
-        "Comment": "frz. parfum",
-        "Revealed": false
+        "Comment": "frz. parfum"
       },
       {
-        "Text": "B\u00FCro",
+        "Text": "Büro",
         "Correct": true,
-        "Comment": "frz. bureau \u2192 B\u00FCro",
-        "Revealed": false
+        "Comment": "frz. bureau → Büro"
       },
       {
         "Text": "Garage",
         "Correct": true,
-        "Comment": "frz. garage",
-        "Revealed": false
+        "Comment": "frz. garage"
       },
       {
         "Text": "Engagement",
         "Correct": true,
-        "Comment": "frz. engagement",
-        "Revealed": false
+        "Comment": "frz. engagement"
       },
       {
         "Text": "Kindergarten",
         "Correct": false,
-        "Comment": "deutsch (ins Englische entlehnt)",
-        "Revealed": false
+        "Comment": "deutsch (ins Englische entlehnt)"
       },
       {
         "Text": "Toilette",
         "Correct": true,
-        "Comment": "frz. toilette",
-        "Revealed": false
+        "Comment": "frz. toilette"
       },
       {
         "Text": "Mannschaft",
         "Correct": false,
-        "Comment": "deutsch",
-        "Revealed": false
+        "Comment": "deutsch"
       },
       {
         "Text": "Niveau",
         "Correct": true,
-        "Comment": "frz. niveau",
-        "Revealed": false
+        "Comment": "frz. niveau"
       },
       {
         "Text": "Portemonnaie",
         "Correct": true,
-        "Comment": "frz. porte-monnaie",
-        "Revealed": false
+        "Comment": "frz. porte-monnaie"
       },
       {
         "Text": "Etage",
         "Correct": true,
-        "Comment": "frz. \u00E9tage",
-        "Revealed": false
+        "Comment": "frz. étage"
       },
       {
         "Text": "Restaurant",
         "Correct": true,
-        "Comment": "frz. restaurant",
-        "Revealed": false
+        "Comment": "frz. restaurant"
       },
       {
         "Text": "Chauffeur",
         "Correct": true,
-        "Comment": "frz. chauffeur",
-        "Revealed": false
+        "Comment": "frz. chauffeur"
       },
       {
         "Text": "Handschuh",
         "Correct": false,
-        "Comment": "deutsch; Handschuh",
-        "Revealed": false
+        "Comment": "deutsch; Handschuh"
       },
       {
         "Text": "Wochenende",
         "Correct": false,
-        "Comment": "deutsch",
-        "Revealed": false
+        "Comment": "deutsch"
       }
     ]
   },
@@ -17292,506 +14588,426 @@
       {
         "Text": "Die Physiker",
         "Correct": true,
-        "Comment": "D\u00FCrrenmatt; Drama",
-        "Revealed": false
+        "Comment": "Dürrenmatt; Drama"
       },
       {
         "Text": "Michael Kohlhaas",
         "Correct": false,
-        "Comment": "Kleist; Novelle",
-        "Revealed": false
+        "Comment": "Kleist; Novelle"
       },
       {
         "Text": "Buddenbrooks",
         "Correct": false,
-        "Comment": "Thomas Mann; Roman",
-        "Revealed": false
+        "Comment": "Thomas Mann; Roman"
       },
       {
         "Text": "Der Process/Prozess",
         "Correct": false,
-        "Comment": "Kafka; Roman",
-        "Revealed": false
+        "Comment": "Kafka; Roman"
       },
       {
         "Text": "Der Steppenwolf",
         "Correct": false,
-        "Comment": "Hesse; Roman",
-        "Revealed": false
+        "Comment": "Hesse; Roman"
       },
       {
         "Text": "Die Leiden des jungen Werther",
         "Correct": false,
-        "Comment": "Goethe; Briefroman",
-        "Revealed": false
+        "Comment": "Goethe; Briefroman"
       },
       {
         "Text": "Maria Stuart",
         "Correct": true,
-        "Comment": "Schiller; Drama",
-        "Revealed": false
+        "Comment": "Schiller; Drama"
       },
       {
         "Text": "Woyzeck",
         "Correct": true,
-        "Comment": "B\u00FCchner; Drama",
-        "Revealed": false
+        "Comment": "Büchner; Drama"
       },
       {
         "Text": "Cassandra",
         "Correct": false,
-        "Comment": "Christa Wolf; Roman",
-        "Revealed": false
+        "Comment": "Christa Wolf; Roman"
       },
       {
         "Text": "Der zerbrochne Krug",
         "Correct": true,
-        "Comment": "Kleist; Drama",
-        "Revealed": false
+        "Comment": "Kleist; Drama"
       },
       {
         "Text": "Iphigenie auf Tauris",
         "Correct": true,
-        "Comment": "Goethe; Drama",
-        "Revealed": false
+        "Comment": "Goethe; Drama"
       },
       {
         "Text": "Der Besuch der alten Dame",
         "Correct": true,
-        "Comment": "D\u00FCrrenmatt; Drama",
-        "Revealed": false
+        "Comment": "Dürrenmatt; Drama"
       },
       {
         "Text": "Effi Briest",
         "Correct": false,
-        "Comment": "Fontane; Roman",
-        "Revealed": false
+        "Comment": "Fontane; Roman"
       },
       {
         "Text": "Die Verwandlung",
         "Correct": false,
-        "Comment": "Kafka; Novelle",
-        "Revealed": false
+        "Comment": "Kafka; Novelle"
       },
       {
         "Text": "Nathan der Weise",
         "Correct": true,
-        "Comment": "Lessing; Drama",
-        "Revealed": false
+        "Comment": "Lessing; Drama"
       },
       {
         "Text": "Faust",
         "Correct": true,
-        "Comment": "Goethe; Drama",
-        "Revealed": false
+        "Comment": "Goethe; Drama"
       }
     ]
   },
   {
-    "Text": "Welche St\u00E4dte sind Hauptst\u00E4dte deutscher Bundesl\u00E4nder?",
+    "Text": "Welche Städte sind Hauptstädte deutscher Bundesländer?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Dresden",
         "Correct": true,
-        "Comment": "Sachsen",
-        "Revealed": false
+        "Comment": "Sachsen"
       },
       {
-        "Text": "M\u00FCnchen",
+        "Text": "München",
         "Correct": true,
-        "Comment": "Bayern",
-        "Revealed": false
+        "Comment": "Bayern"
       },
       {
-        "Text": "Saarbr\u00FCcken",
+        "Text": "Saarbrücken",
         "Correct": true,
-        "Comment": "Saarland",
-        "Revealed": false
+        "Comment": "Saarland"
       },
       {
         "Text": "Potsdam",
         "Correct": true,
-        "Comment": "Brandenburg",
-        "Revealed": false
+        "Comment": "Brandenburg"
       },
       {
         "Text": "Kiel",
         "Correct": true,
-        "Comment": "Schleswig-Holstein",
-        "Revealed": false
+        "Comment": "Schleswig-Holstein"
       },
       {
         "Text": "Wiesbaden",
         "Correct": true,
-        "Comment": "Hessen",
-        "Revealed": false
+        "Comment": "Hessen"
       },
       {
         "Text": "Magdeburg",
         "Correct": true,
-        "Comment": "Sachsen-Anhalt",
-        "Revealed": false
+        "Comment": "Sachsen-Anhalt"
       },
       {
         "Text": "Schwerin",
         "Correct": true,
-        "Comment": "Mecklenburg-Vorpommern",
-        "Revealed": false
+        "Comment": "Mecklenburg-Vorpommern"
       },
       {
         "Text": "Stuttgart",
         "Correct": true,
-        "Comment": "Baden-W\u00FCrttemberg",
-        "Revealed": false
+        "Comment": "Baden-Württemberg"
       },
       {
-        "Text": "K\u00F6ln",
+        "Text": "Köln",
         "Correct": false,
-        "Comment": "NRW-Hauptstadt ist D\u00FCsseldorf",
-        "Revealed": false
+        "Comment": "NRW-Hauptstadt ist Düsseldorf"
       },
       {
         "Text": "Hannover",
         "Correct": true,
-        "Comment": "Niedersachsen",
-        "Revealed": false
+        "Comment": "Niedersachsen"
       },
       {
         "Text": "Berlin",
         "Correct": true,
-        "Comment": "Stadtstaat/Bundeshauptstadt",
-        "Revealed": false
+        "Comment": "Stadtstaat/Bundeshauptstadt"
       },
       {
         "Text": "Mainz",
         "Correct": true,
-        "Comment": "Rheinland-Pfalz",
-        "Revealed": false
+        "Comment": "Rheinland-Pfalz"
       },
       {
-        "Text": "D\u00FCsseldorf",
+        "Text": "Düsseldorf",
         "Correct": true,
-        "Comment": "Nordrhein-Westfalen",
-        "Revealed": false
+        "Comment": "Nordrhein-Westfalen"
       },
       {
         "Text": "Erfurt",
         "Correct": true,
-        "Comment": "Th\u00FCringen",
-        "Revealed": false
+        "Comment": "Thüringen"
       },
       {
-        "Text": "N\u00FCrnberg",
+        "Text": "Nürnberg",
         "Correct": false,
-        "Comment": "Bayern-Hauptstadt ist M\u00FCnchen",
-        "Revealed": false
+        "Comment": "Bayern-Hauptstadt ist München"
       }
     ]
   },
   {
-    "Text": "Welche L\u00E4nder waren Gr\u00FCndungsmitglieder der EWG (R\u00F6mische Vertr\u00E4ge 1957)?",
+    "Text": "Welche Länder waren Gründungsmitglieder der EWG (Römische Verträge 1957)?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Niederlande",
         "Correct": true,
-        "Comment": "seit 1957",
-        "Revealed": false
+        "Comment": "seit 1957"
       },
       {
         "Text": "Norwegen",
         "Correct": false,
-        "Comment": "nie beigetreten",
-        "Revealed": false
+        "Comment": "nie beigetreten"
       },
       {
         "Text": "Frankreich",
         "Correct": true,
-        "Comment": "seit 1957",
-        "Revealed": false
+        "Comment": "seit 1957"
       },
       {
         "Text": "Schweden",
         "Correct": false,
-        "Comment": "Beitritt 1995",
-        "Revealed": false
+        "Comment": "Beitritt 1995"
       },
       {
         "Text": "Spanien",
         "Correct": false,
-        "Comment": "Beitritt 1986",
-        "Revealed": false
+        "Comment": "Beitritt 1986"
       },
       {
-        "Text": "D\u00E4nemark",
+        "Text": "Dänemark",
         "Correct": false,
-        "Comment": "Beitritt 1973",
-        "Revealed": false
+        "Comment": "Beitritt 1973"
       },
       {
         "Text": "Luxemburg",
         "Correct": true,
-        "Comment": "seit 1957",
-        "Revealed": false
+        "Comment": "seit 1957"
       },
       {
         "Text": "Griechenland",
         "Correct": false,
-        "Comment": "Beitritt 1981",
-        "Revealed": false
+        "Comment": "Beitritt 1981"
       },
       {
         "Text": "Polen",
         "Correct": false,
-        "Comment": "Beitritt 2004",
-        "Revealed": false
+        "Comment": "Beitritt 2004"
       },
       {
         "Text": "Irland",
         "Correct": false,
-        "Comment": "Beitritt 1973",
-        "Revealed": false
+        "Comment": "Beitritt 1973"
       },
       {
         "Text": "Italien",
         "Correct": true,
-        "Comment": "seit 1957",
-        "Revealed": false
+        "Comment": "seit 1957"
       },
       {
         "Text": "Belgien",
         "Correct": true,
-        "Comment": "seit 1957",
-        "Revealed": false
+        "Comment": "seit 1957"
       },
       {
-        "Text": "\u00D6sterreich",
+        "Text": "Österreich",
         "Correct": false,
-        "Comment": "Beitritt 1995",
-        "Revealed": false
+        "Comment": "Beitritt 1995"
       },
       {
         "Text": "Bundesrepublik Deutschland",
         "Correct": true,
-        "Comment": "seit 1957",
-        "Revealed": false
+        "Comment": "seit 1957"
       },
       {
-        "Text": "Vereinigtes K\u00F6nigreich",
+        "Text": "Vereinigtes Königreich",
         "Correct": false,
-        "Comment": "Beitritt 1973",
-        "Revealed": false
+        "Comment": "Beitritt 1973"
       },
       {
         "Text": "Portugal",
         "Correct": false,
-        "Comment": "Beitritt 1986",
-        "Revealed": false
+        "Comment": "Beitritt 1986"
       }
     ]
   },
   {
-    "Text": "Welche Inseln geh\u00F6ren politisch zu Italien?",
+    "Text": "Welche Inseln gehören politisch zu Italien?",
     "Selected": false,
     "Answers": [
       {
         "Text": "La Maddalena",
         "Correct": true,
-        "Comment": "Sardinien-Archipel",
-        "Revealed": false
+        "Comment": "Sardinien-Archipel"
       },
       {
         "Text": "Ischia",
         "Correct": true,
-        "Comment": "Golf von Neapel",
-        "Revealed": false
+        "Comment": "Golf von Neapel"
       },
       {
         "Text": "Korfu",
         "Correct": false,
-        "Comment": "Griechenland",
-        "Revealed": false
+        "Comment": "Griechenland"
       },
       {
         "Text": "Capri",
         "Correct": true,
-        "Comment": "bei Neapel",
-        "Revealed": false
+        "Comment": "bei Neapel"
       },
       {
         "Text": "Elba",
         "Correct": true,
-        "Comment": "Toskana",
-        "Revealed": false
+        "Comment": "Toskana"
       },
       {
         "Text": "Linosa",
         "Correct": true,
-        "Comment": "Pelagische Inseln",
-        "Revealed": false
+        "Comment": "Pelagische Inseln"
       },
       {
         "Text": "Vulcano",
         "Correct": true,
-        "Comment": "\u00C4olische Inseln",
-        "Revealed": false
+        "Comment": "Äolische Inseln"
       },
       {
         "Text": "Lampedusa",
         "Correct": true,
-        "Comment": "Pelagische Inseln",
-        "Revealed": false
+        "Comment": "Pelagische Inseln"
       },
       {
         "Text": "Lipari",
         "Correct": true,
-        "Comment": "\u00C4olische Inseln",
-        "Revealed": false
+        "Comment": "Äolische Inseln"
       },
       {
         "Text": "Sardinien",
         "Correct": true,
-        "Comment": "Italien; zweitgr\u00F6\u00DFte",
-        "Revealed": false
+        "Comment": "Italien; zweitgrößte"
       },
       {
         "Text": "Stromboli",
         "Correct": true,
-        "Comment": "\u00C4olische Inseln",
-        "Revealed": false
+        "Comment": "Äolische Inseln"
       },
       {
         "Text": "Pantelleria",
         "Correct": true,
-        "Comment": "zwischen Sizilien/Tunesien",
-        "Revealed": false
+        "Comment": "zwischen Sizilien/Tunesien"
       },
       {
         "Text": "Giglio",
         "Correct": true,
-        "Comment": "Toskana",
-        "Revealed": false
+        "Comment": "Toskana"
       },
       {
         "Text": "Korsika",
         "Correct": false,
-        "Comment": "Frankreich",
-        "Revealed": false
+        "Comment": "Frankreich"
       },
       {
         "Text": "Sizilien",
         "Correct": true,
-        "Comment": "Italien; gr\u00F6\u00DFte Mittelmeerinsel",
-        "Revealed": false
+        "Comment": "Italien; größte Mittelmeerinsel"
       },
       {
         "Text": "Procida",
         "Correct": true,
-        "Comment": "bei Neapel",
-        "Revealed": false
+        "Comment": "bei Neapel"
       }
     ]
   },
   {
-    "Text": "Welche Gem\u00E4lde/Werke geh\u00F6ren zum Barock?",
+    "Text": "Welche Gemälde/Werke gehören zum Barock?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Guernica (Picasso)",
         "Correct": false,
-        "Comment": "1937; Kubismus",
-        "Revealed": false
+        "Comment": "1937; Kubismus"
       },
       {
         "Text": "Die Anatomie des Dr. Tulp (Rembrandt)",
         "Correct": true,
-        "Comment": "1632; Barock",
-        "Revealed": false
+        "Comment": "1632; Barock"
       },
       {
         "Text": "Allegorie der Malerei (Vermeer)",
         "Correct": true,
-        "Comment": "ca. 1666\u201368; Barock",
-        "Revealed": false
+        "Comment": "ca. 1666–68; Barock"
       },
       {
-        "Text": "M\u00E4dchen mit dem Perlenohrring (Vermeer)",
+        "Text": "Mädchen mit dem Perlenohrring (Vermeer)",
         "Correct": true,
-        "Comment": "ca. 1665; Barock",
-        "Revealed": false
+        "Comment": "ca. 1665; Barock"
       },
       {
         "Text": "Die Schule von Athen (Raffael)",
         "Correct": false,
-        "Comment": "1510/11; Hochrenaissance",
-        "Revealed": false
+        "Comment": "1510/11; Hochrenaissance"
       },
       {
         "Text": "Judith enthauptet Holofernes (Caravaggio)",
         "Correct": true,
-        "Comment": "ca. 1599; Fr\u00FChbarock",
-        "Revealed": false
+        "Comment": "ca. 1599; Frühbarock"
       },
       {
         "Text": "Die Nachtwache (Rembrandt)",
         "Correct": true,
-        "Comment": "1642; Barock/Niederl\u00E4nd. Goldenes Zeitalter",
-        "Revealed": false
+        "Comment": "1642; Barock/Niederländ. Goldenes Zeitalter"
       },
       {
-        "Text": "Die gro\u00DFe Welle von Kanagawa (Hokusai)",
+        "Text": "Die große Welle von Kanagawa (Hokusai)",
         "Correct": false,
-        "Comment": "1830er; Ukiyo-e",
-        "Revealed": false
+        "Comment": "1830er; Ukiyo-e"
       },
       {
-        "Text": "Campbell\u2019s Soup Cans (Warhol)",
+        "Text": "Campbell’s Soup Cans (Warhol)",
         "Correct": false,
-        "Comment": "1962; Pop-Art",
-        "Revealed": false
+        "Comment": "1962; Pop-Art"
       },
       {
         "Text": "Die Geburt der Venus (Botticelli)",
         "Correct": false,
-        "Comment": "1480er; Renaissance",
-        "Revealed": false
+        "Comment": "1480er; Renaissance"
       },
       {
         "Text": "Impression, Sonnenaufgang (Monet)",
         "Correct": false,
-        "Comment": "1872; Impressionismus",
-        "Revealed": false
+        "Comment": "1872; Impressionismus"
       },
       {
-        "Text": "Berufung des hl. Matth\u00E4us (Caravaggio)",
+        "Text": "Berufung des hl. Matthäus (Caravaggio)",
         "Correct": true,
-        "Comment": "1599\u20131600; Barock",
-        "Revealed": false
+        "Comment": "1599–1600; Barock"
       },
       {
-        "Text": "Las Meninas (Vel\u00E1zquez)",
+        "Text": "Las Meninas (Velázquez)",
         "Correct": true,
-        "Comment": "1656; spanischer Barock",
-        "Revealed": false
+        "Comment": "1656; spanischer Barock"
       },
       {
         "Text": "Der Schrei (Munch)",
         "Correct": false,
-        "Comment": "1893; Expressionismus",
-        "Revealed": false
+        "Comment": "1893; Expressionismus"
       },
       {
         "Text": "Die Ekstase der hl. Teresa (Bernini)",
         "Correct": true,
-        "Comment": "1652; Skulptur, r\u00F6mischer Barock",
-        "Revealed": false
+        "Comment": "1652; Skulptur, römischer Barock"
       },
       {
         "Text": "Die Schule von Athen (Raffael)",
         "Correct": false,
-        "Comment": "1510/11; Hochrenaissance",
-        "Revealed": false
+        "Comment": "1510/11; Hochrenaissance"
       }
     ]
   },
@@ -17802,188 +15018,158 @@
       {
         "Text": "Hermann Hesse",
         "Correct": true,
-        "Comment": "1946",
-        "Revealed": false
+        "Comment": "1946"
       },
       {
         "Text": "Thomas Mann",
         "Correct": true,
-        "Comment": "1929",
-        "Revealed": false
+        "Comment": "1929"
       },
       {
         "Text": "Orhan Pamuk",
         "Correct": true,
-        "Comment": "2006",
-        "Revealed": false
+        "Comment": "2006"
       },
       {
         "Text": "James Joyce",
         "Correct": false,
-        "Comment": "nie ausgezeichnet",
-        "Revealed": false
+        "Comment": "nie ausgezeichnet"
       },
       {
-        "Text": "Heinrich B\u00F6ll",
+        "Text": "Heinrich Böll",
         "Correct": true,
-        "Comment": "1972",
-        "Revealed": false
+        "Comment": "1972"
       },
       {
         "Text": "Albert Camus",
         "Correct": true,
-        "Comment": "1957",
-        "Revealed": false
+        "Comment": "1957"
       },
       {
-        "Text": "G\u00FCnter Grass",
+        "Text": "Günter Grass",
         "Correct": true,
-        "Comment": "1999",
-        "Revealed": false
+        "Comment": "1999"
       },
       {
         "Text": "Bob Dylan",
         "Correct": true,
-        "Comment": "2016",
-        "Revealed": false
+        "Comment": "2016"
       },
       {
         "Text": "Kazuo Ishiguro",
         "Correct": true,
-        "Comment": "2017",
-        "Revealed": false
+        "Comment": "2017"
       },
       {
         "Text": "Jorge Luis Borges",
         "Correct": false,
-        "Comment": "nie ausgezeichnet",
-        "Revealed": false
+        "Comment": "nie ausgezeichnet"
       },
       {
         "Text": "Virginia Woolf",
         "Correct": false,
-        "Comment": "nie ausgezeichnet",
-        "Revealed": false
+        "Comment": "nie ausgezeichnet"
       },
       {
         "Text": "Samuel Beckett",
         "Correct": true,
-        "Comment": "1969",
-        "Revealed": false
+        "Comment": "1969"
       },
       {
         "Text": "Pablo Neruda",
         "Correct": true,
-        "Comment": "1971",
-        "Revealed": false
+        "Comment": "1971"
       },
       {
         "Text": "Olga Tokarczuk",
         "Correct": true,
-        "Comment": "2018",
-        "Revealed": false
+        "Comment": "2018"
       },
       {
         "Text": "Leo Tolstoi",
         "Correct": false,
-        "Comment": "nie ausgezeichnet",
-        "Revealed": false
+        "Comment": "nie ausgezeichnet"
       },
       {
-        "Text": "Gabriel Garc\u00EDa M\u00E1rquez",
+        "Text": "Gabriel García Márquez",
         "Correct": true,
-        "Comment": "1982",
-        "Revealed": false
+        "Comment": "1982"
       }
     ]
   },
   {
-    "Text": "Welche Erfindungen stammen aus dem D-A-CH-Raum (Deutschland/\u00D6sterreich/Schweiz)?",
+    "Text": "Welche Erfindungen stammen aus dem D-A-CH-Raum (Deutschland/Österreich/Schweiz)?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Plexiglas (PMMA)",
         "Correct": true,
-        "Comment": "1933; R\u00F6hm (DE)",
-        "Revealed": false
+        "Comment": "1933; Röhm (DE)"
       },
       {
         "Text": "Velcro? (Klettband Marke)",
         "Correct": true,
-        "Comment": "Marke aus CH",
-        "Revealed": false
+        "Comment": "Marke aus CH"
       },
       {
         "Text": "Kaffeefilter",
         "Correct": true,
-        "Comment": "1908; Melitta Bentz (DE)",
-        "Revealed": false
+        "Comment": "1908; Melitta Bentz (DE)"
       },
       {
         "Text": "Teflon",
         "Correct": false,
-        "Comment": "1938; Plunkett (USA)",
-        "Revealed": false
+        "Comment": "1938; Plunkett (USA)"
       },
       {
-        "Text": "D\u00FCbel (Nylond\u00FCbel)",
+        "Text": "Dübel (Nylondübel)",
         "Correct": true,
-        "Comment": "1958; Artur Fischer (DE)",
-        "Revealed": false
+        "Comment": "1958; Artur Fischer (DE)"
       },
       {
         "Text": "Dieselmotor",
         "Correct": true,
-        "Comment": "1897; Rudolf Diesel (DE)",
-        "Revealed": false
+        "Comment": "1897; Rudolf Diesel (DE)"
       },
       {
         "Text": "Jeans",
         "Correct": false,
-        "Comment": "Levi Strauss (USA)",
-        "Revealed": false
+        "Comment": "Levi Strauss (USA)"
       },
       {
         "Text": "Laser",
         "Correct": false,
-        "Comment": "1960; Maiman (USA)",
-        "Revealed": false
+        "Comment": "1960; Maiman (USA)"
       },
       {
         "Text": "Kugelschreiber",
         "Correct": false,
-        "Comment": "L\u00E1szl\u00F3 B\u00EDr\u00F3 (AR/HU)",
-        "Revealed": false
+        "Comment": "László Bíró (AR/HU)"
       },
       {
         "Text": "MP3-Verfahren",
         "Correct": true,
-        "Comment": "1990er; Fraunhofer IIS (DE)",
-        "Revealed": false
+        "Comment": "1990er; Fraunhofer IIS (DE)"
       },
       {
         "Text": "Post-it",
         "Correct": false,
-        "Comment": "3M (USA)",
-        "Revealed": false
+        "Comment": "3M (USA)"
       },
       {
         "Text": "Aspirin",
         "Correct": true,
-        "Comment": "1897; Bayer (DE)",
-        "Revealed": false
+        "Comment": "1897; Bayer (DE)"
       },
       {
         "Text": "Quarzarmbanduhr",
         "Correct": true,
-        "Comment": "1967 Prototyp; Neuch\u00E2tel (CH)",
-        "Revealed": false
+        "Comment": "1967 Prototyp; Neuchâtel (CH)"
       },
       {
         "Text": "Dynamit",
         "Correct": false,
-        "Comment": "1867; Alfred Nobel (SE)",
-        "Revealed": false
+        "Comment": "1867; Alfred Nobel (SE)"
       }
     ]
   },
@@ -17994,506 +15180,426 @@
       {
         "Text": "Mark Twain",
         "Correct": true,
-        "Comment": "Samuel Langhorne Clemens",
-        "Revealed": false
+        "Comment": "Samuel Langhorne Clemens"
       },
       {
         "Text": "Thomas Mann",
         "Correct": false,
-        "Comment": "eigener Name",
-        "Revealed": false
+        "Comment": "eigener Name"
       },
       {
         "Text": "Voltaire",
         "Correct": true,
-        "Comment": "Fran\u00E7ois-Marie Arouet",
-        "Revealed": false
+        "Comment": "François-Marie Arouet"
       },
       {
         "Text": "George Orwell",
         "Correct": true,
-        "Comment": "Eric Arthur Blair",
-        "Revealed": false
+        "Comment": "Eric Arthur Blair"
       },
       {
         "Text": "Ernest Hemingway",
         "Correct": false,
-        "Comment": "eigener Name",
-        "Revealed": false
+        "Comment": "eigener Name"
       },
       {
         "Text": "Ringelnatz",
         "Correct": true,
-        "Comment": "Hans B\u00F6tticher",
-        "Revealed": false
+        "Comment": "Hans Bötticher"
       },
       {
         "Text": "Alexandre Dumas",
         "Correct": false,
-        "Comment": "eigener Name",
-        "Revealed": false
+        "Comment": "eigener Name"
       },
       {
         "Text": "Novalis",
         "Correct": true,
-        "Comment": "Georg Philipp Friedrich von Hardenberg",
-        "Revealed": false
+        "Comment": "Georg Philipp Friedrich von Hardenberg"
       },
       {
         "Text": "Lewis Carroll",
         "Correct": true,
-        "Comment": "Charles Lutwidge Dodgson",
-        "Revealed": false
+        "Comment": "Charles Lutwidge Dodgson"
       },
       {
         "Text": "Virginia Woolf",
         "Correct": false,
-        "Comment": "eigener Name",
-        "Revealed": false
+        "Comment": "eigener Name"
       },
       {
-        "Text": "Moli\u00E8re",
+        "Text": "Molière",
         "Correct": true,
-        "Comment": "Jean-Baptiste Poquelin",
-        "Revealed": false
+        "Comment": "Jean-Baptiste Poquelin"
       },
       {
         "Text": "Leo Tolstoi",
         "Correct": false,
-        "Comment": "eigener Name",
-        "Revealed": false
+        "Comment": "eigener Name"
       },
       {
         "Text": "Saki",
         "Correct": true,
-        "Comment": "Hector Hugh Munro",
-        "Revealed": false
+        "Comment": "Hector Hugh Munro"
       },
       {
         "Text": "Friedrich Schiller",
         "Correct": false,
-        "Comment": "eigener Name",
-        "Revealed": false
+        "Comment": "eigener Name"
       },
       {
         "Text": "Stan Lee",
         "Correct": true,
-        "Comment": "Stanley Martin Lieber",
-        "Revealed": false
+        "Comment": "Stanley Martin Lieber"
       },
       {
         "Text": "Arthur Conan Doyle",
         "Correct": false,
-        "Comment": "eigener Name",
-        "Revealed": false
+        "Comment": "eigener Name"
       }
     ]
   },
   {
-    "Text": "Welche der folgenden physikalischen Experimente wurden vor 1900 durchgef\u00FChrt?",
+    "Text": "Welche der folgenden physikalischen Experimente wurden vor 1900 durchgeführt?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "Michelson\u2013Morley-Experiment",
+        "Text": "Michelson–Morley-Experiment",
         "Correct": true,
-        "Comment": "1887",
-        "Revealed": false
+        "Comment": "1887"
       },
       {
-        "Text": "Stern\u2013Gerlach-Experiment",
+        "Text": "Stern–Gerlach-Experiment",
         "Correct": false,
-        "Comment": "1922",
-        "Revealed": false
+        "Comment": "1922"
       },
       {
         "Text": "Cavendish-Experiment (Dichte der Erde/Gravitationskonstante)",
         "Correct": true,
-        "Comment": "1797\u201398",
-        "Revealed": false
+        "Comment": "1797–98"
       },
       {
         "Text": "Rutherford-Streuversuch (Goldfolie)",
         "Correct": false,
-        "Comment": "1909",
-        "Revealed": false
+        "Comment": "1909"
       },
       {
         "Text": "Youngs Doppelspalt",
         "Correct": true,
-        "Comment": "1801",
-        "Revealed": false
+        "Comment": "1801"
       },
       {
-        "Text": "Millikans \u00D6ltr\u00F6pfchen-Experiment",
+        "Text": "Millikans Öltröpfchen-Experiment",
         "Correct": false,
-        "Comment": "1909\u20131911",
-        "Revealed": false
+        "Comment": "1909–1911"
       },
       {
         "Text": "Fizeau: Lichtgeschwindigkeit im Wasser",
         "Correct": true,
-        "Comment": "1849",
-        "Revealed": false
+        "Comment": "1849"
       },
       {
         "Text": "Foucaults Pendel",
         "Correct": true,
-        "Comment": "1851",
-        "Revealed": false
+        "Comment": "1851"
       },
       {
         "Text": "Faraday: elektromagnetische Induktion",
         "Correct": true,
-        "Comment": "1831",
-        "Revealed": false
+        "Comment": "1831"
       },
       {
         "Text": "Oersted: Magnetnadel und Strom",
         "Correct": true,
-        "Comment": "1820",
-        "Revealed": false
+        "Comment": "1820"
       },
       {
         "Text": "Hertz: Nachweis elektromagnetischer Wellen",
         "Correct": true,
-        "Comment": "1886\u201388",
-        "Revealed": false
+        "Comment": "1886–88"
       },
       {
-        "Text": "Davisson\u2013Germer-Experiment",
+        "Text": "Davisson–Germer-Experiment",
         "Correct": false,
-        "Comment": "1927",
-        "Revealed": false
+        "Comment": "1927"
       },
       {
-        "Text": "Franck\u2013Hertz-Experiment",
+        "Text": "Franck–Hertz-Experiment",
         "Correct": false,
-        "Comment": "1914",
-        "Revealed": false
+        "Comment": "1914"
       },
       {
-        "Text": "Joules Paddelrad-Versuch (Mechanik\u2192W\u00E4rme)",
+        "Text": "Joules Paddelrad-Versuch (Mechanik→Wärme)",
         "Correct": true,
-        "Comment": "1840er",
-        "Revealed": false
+        "Comment": "1840er"
       },
       {
-        "Text": "Michelson\u2013Gale-Experiment",
+        "Text": "Michelson–Gale-Experiment",
         "Correct": false,
-        "Comment": "1925",
-        "Revealed": false
+        "Comment": "1925"
       },
       {
         "Text": "Galileis schiefe Ebene/Fallgesetze",
         "Correct": true,
-        "Comment": "ca. 1600er",
-        "Revealed": false
+        "Comment": "ca. 1600er"
       }
     ]
   },
   {
-    "Text": "Diese Himmelsk\u00F6rper wurden erst teleskopisch entdeckt (nicht schon in der Antike bekannt) \u2013 welche?",
+    "Text": "Diese Himmelskörper wurden erst teleskopisch entdeckt (nicht schon in der Antike bekannt) – welche?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Uranus",
         "Correct": true,
-        "Comment": "1781; Herschel",
-        "Revealed": false
+        "Comment": "1781; Herschel"
       },
       {
         "Text": "Neptun",
         "Correct": true,
-        "Comment": "1846; Galle/Le Verrier",
-        "Revealed": false
+        "Comment": "1846; Galle/Le Verrier"
       },
       {
         "Text": "Pluto",
         "Correct": true,
-        "Comment": "1930; Tombaugh",
-        "Revealed": false
+        "Comment": "1930; Tombaugh"
       },
       {
         "Text": "Ceres",
         "Correct": true,
-        "Comment": "1801; Piazzi",
-        "Revealed": false
+        "Comment": "1801; Piazzi"
       },
       {
         "Text": "Pallas",
         "Correct": true,
-        "Comment": "1802; Olbers",
-        "Revealed": false
+        "Comment": "1802; Olbers"
       },
       {
         "Text": "Vesta",
         "Correct": true,
-        "Comment": "1807; Olbers",
-        "Revealed": false
+        "Comment": "1807; Olbers"
       },
       {
         "Text": "Ganymed (Jupitermond)",
         "Correct": true,
-        "Comment": "1610; Galilei",
-        "Revealed": false
+        "Comment": "1610; Galilei"
       },
       {
         "Text": "Titan (Saturnmond)",
         "Correct": true,
-        "Comment": "1655; Huygens",
-        "Revealed": false
+        "Comment": "1655; Huygens"
       },
       {
         "Text": "Triton (Neptunmond)",
         "Correct": true,
-        "Comment": "1846; Lassell",
-        "Revealed": false
+        "Comment": "1846; Lassell"
       },
       {
         "Text": "Callisto (Jupitermond)",
         "Correct": true,
-        "Comment": "1610; Galilei",
-        "Revealed": false
+        "Comment": "1610; Galilei"
       },
       {
         "Text": "Merkur",
         "Correct": false,
-        "Comment": "seit der Antike bekannt (nackt sichtbar)",
-        "Revealed": false
+        "Comment": "seit der Antike bekannt (nackt sichtbar)"
       },
       {
         "Text": "Venus",
         "Correct": false,
-        "Comment": "seit der Antike bekannt (nackt sichtbar)",
-        "Revealed": false
+        "Comment": "seit der Antike bekannt (nackt sichtbar)"
       },
       {
         "Text": "Mars",
         "Correct": false,
-        "Comment": "seit der Antike bekannt (nackt sichtbar)",
-        "Revealed": false
+        "Comment": "seit der Antike bekannt (nackt sichtbar)"
       },
       {
         "Text": "Jupiter",
         "Correct": false,
-        "Comment": "seit der Antike bekannt (nackt sichtbar)",
-        "Revealed": false
+        "Comment": "seit der Antike bekannt (nackt sichtbar)"
       },
       {
         "Text": "Saturn",
         "Correct": false,
-        "Comment": "seit der Antike bekannt (nackt sichtbar)",
-        "Revealed": false
+        "Comment": "seit der Antike bekannt (nackt sichtbar)"
       },
       {
         "Text": "Sirius",
         "Correct": false,
-        "Comment": "seit der Antike bekannt (Stern)",
-        "Revealed": false
+        "Comment": "seit der Antike bekannt (Stern)"
       }
     ]
   },
   {
-    "Text": "In die Donau m\u00FCnden \u2013 direkt oder \u00FCber Nebenfl\u00FCsse: Welche davon?",
+    "Text": "In die Donau münden – direkt oder über Nebenflüsse: Welche davon?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Inn",
         "Correct": true,
-        "Comment": "Nebenfluss; m\u00FCndet bei Passau",
-        "Revealed": false
+        "Comment": "Nebenfluss; mündet bei Passau"
       },
       {
         "Text": "Isar",
         "Correct": true,
-        "Comment": "Nebenfluss; m\u00FCndet bei Deggendorf",
-        "Revealed": false
+        "Comment": "Nebenfluss; mündet bei Deggendorf"
       },
       {
         "Text": "Lech",
         "Correct": true,
-        "Comment": "Nebenfluss; m\u00FCndet bei Donauw\u00F6rth",
-        "Revealed": false
+        "Comment": "Nebenfluss; mündet bei Donauwörth"
       },
       {
         "Text": "Iller",
         "Correct": true,
-        "Comment": "Nebenfluss; m\u00FCndet bei Ulm",
-        "Revealed": false
+        "Comment": "Nebenfluss; mündet bei Ulm"
       },
       {
-        "Text": "Altm\u00FChl",
+        "Text": "Altmühl",
         "Correct": true,
-        "Comment": "Nebenfluss; m\u00FCndet bei Kelheim",
-        "Revealed": false
+        "Comment": "Nebenfluss; mündet bei Kelheim"
       },
       {
         "Text": "Naab",
         "Correct": true,
-        "Comment": "Nebenfluss; m\u00FCndet bei Regensburg",
-        "Revealed": false
+        "Comment": "Nebenfluss; mündet bei Regensburg"
       },
       {
         "Text": "March (Morava)",
         "Correct": true,
-        "Comment": "Nebenfluss; m\u00FCndet bei Bratislava",
-        "Revealed": false
+        "Comment": "Nebenfluss; mündet bei Bratislava"
       },
       {
         "Text": "Sava",
         "Correct": true,
-        "Comment": "Nebenfluss; m\u00FCndet in Belgrad",
-        "Revealed": false
+        "Comment": "Nebenfluss; mündet in Belgrad"
       },
       {
         "Text": "Drau (Drava)",
         "Correct": true,
-        "Comment": "Nebenfluss; m\u00FCndet in Kroatien",
-        "Revealed": false
+        "Comment": "Nebenfluss; mündet in Kroatien"
       },
       {
-        "Text": "Thei\u00DF (Tisza)",
+        "Text": "Theiß (Tisza)",
         "Correct": true,
-        "Comment": "Nebenfluss; m\u00FCndet bei Titel (RS)",
-        "Revealed": false
+        "Comment": "Nebenfluss; mündet bei Titel (RS)"
       },
       {
         "Text": "Pruth (Prut)",
         "Correct": true,
-        "Comment": "Nebenfluss; m\u00FCndet nahe Galati",
-        "Revealed": false
+        "Comment": "Nebenfluss; mündet nahe Galati"
       },
       {
         "Text": "Alt (Olt)",
         "Correct": true,
-        "Comment": "Nebenfluss; m\u00FCndet in Rum\u00E4nien",
-        "Revealed": false
+        "Comment": "Nebenfluss; mündet in Rumänien"
       },
       {
         "Text": "Rhein",
         "Correct": false,
-        "Comment": "Nordsee; nicht Donau",
-        "Revealed": false
+        "Comment": "Nordsee; nicht Donau"
       },
       {
         "Text": "Elbe",
         "Correct": false,
-        "Comment": "Nordsee; nicht Donau",
-        "Revealed": false
+        "Comment": "Nordsee; nicht Donau"
       },
       {
         "Text": "Oder",
         "Correct": false,
-        "Comment": "Ostsee; nicht Donau",
-        "Revealed": false
+        "Comment": "Ostsee; nicht Donau"
       },
       {
         "Text": "Po",
         "Correct": false,
-        "Comment": "Adria; nicht Donau",
-        "Revealed": false
+        "Comment": "Adria; nicht Donau"
       }
     ]
   },
   {
-    "Text": "Aus der Sammlung der Br\u00FCder Grimm: Welche M\u00E4rchen geh\u00F6ren dazu?",
+    "Text": "Aus der Sammlung der Brüder Grimm: Welche Märchen gehören dazu?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "H\u00E4nsel und Gretel",
+        "Text": "Hänsel und Gretel",
         "Correct": true,
-        "Comment": "Grimm, KHM",
-        "Revealed": false
+        "Comment": "Grimm, KHM"
       },
       {
-        "Text": "Rotk\u00E4ppchen",
+        "Text": "Rotkäppchen",
         "Correct": true,
-        "Comment": "Grimm, KHM",
-        "Revealed": false
+        "Comment": "Grimm, KHM"
       },
       {
         "Text": "Schneewittchen",
         "Correct": true,
-        "Comment": "Grimm, KHM",
-        "Revealed": false
+        "Comment": "Grimm, KHM"
       },
       {
         "Text": "Aschenputtel",
         "Correct": true,
-        "Comment": "Grimm, KHM",
-        "Revealed": false
+        "Comment": "Grimm, KHM"
       },
       {
-        "Text": "Dornr\u00F6schen",
+        "Text": "Dornröschen",
         "Correct": true,
-        "Comment": "Grimm, KHM",
-        "Revealed": false
+        "Comment": "Grimm, KHM"
       },
       {
-        "Text": "Der Froschk\u00F6nig",
+        "Text": "Der Froschkönig",
         "Correct": true,
-        "Comment": "Grimm, KHM",
-        "Revealed": false
+        "Comment": "Grimm, KHM"
       },
       {
         "Text": "Die Bremer Stadtmusikanten",
         "Correct": true,
-        "Comment": "Grimm, KHM",
-        "Revealed": false
+        "Comment": "Grimm, KHM"
       },
       {
         "Text": "Frau Holle",
         "Correct": true,
-        "Comment": "Grimm, KHM",
-        "Revealed": false
+        "Comment": "Grimm, KHM"
       },
       {
-        "Text": "Der Wolf und die sieben Gei\u00DFlein",
+        "Text": "Der Wolf und die sieben Geißlein",
         "Correct": true,
-        "Comment": "Grimm, KHM",
-        "Revealed": false
+        "Comment": "Grimm, KHM"
       },
       {
         "Text": "Rumpelstilzchen",
         "Correct": true,
-        "Comment": "Grimm, KHM",
-        "Revealed": false
+        "Comment": "Grimm, KHM"
       },
       {
         "Text": "Die kleine Meerjungfrau",
         "Correct": false,
-        "Comment": "Andersen",
-        "Revealed": false
+        "Comment": "Andersen"
       },
       {
         "Text": "Pinocchio",
         "Correct": false,
-        "Comment": "Collodi",
-        "Revealed": false
+        "Comment": "Collodi"
       },
       {
         "Text": "Peter Pan",
         "Correct": false,
-        "Comment": "Barrie",
-        "Revealed": false
+        "Comment": "Barrie"
       },
       {
         "Text": "Pippi Langstrumpf",
         "Correct": false,
-        "Comment": "Lindgren",
-        "Revealed": false
+        "Comment": "Lindgren"
       },
       {
         "Text": "Der Zauberer von Oz",
         "Correct": false,
-        "Comment": "L. Frank Baum",
-        "Revealed": false
+        "Comment": "L. Frank Baum"
       },
       {
         "Text": "Alice im Wunderland",
         "Correct": false,
-        "Comment": "Lewis Carroll",
-        "Revealed": false
+        "Comment": "Lewis Carroll"
       }
     ]
   },
@@ -18502,304 +15608,256 @@
     "Selected": false,
     "Answers": [
       {
-        "Text": "\u00C4tna",
+        "Text": "Ätna",
         "Correct": true,
-        "Comment": "Italien; h\u00E4ufig aktiv",
-        "Revealed": false
+        "Comment": "Italien; häufig aktiv"
       },
       {
         "Text": "Stromboli",
         "Correct": true,
-        "Comment": "Italien; daueraktiv",
-        "Revealed": false
+        "Comment": "Italien; daueraktiv"
       },
       {
         "Text": "Vesuv",
         "Correct": true,
-        "Comment": "Italien; letzte Eruption 1944",
-        "Revealed": false
+        "Comment": "Italien; letzte Eruption 1944"
       },
       {
-        "Text": "K\u012Blauea",
+        "Text": "Kīlauea",
         "Correct": true,
-        "Comment": "Hawaii; sehr aktiv",
-        "Revealed": false
+        "Comment": "Hawaii; sehr aktiv"
       },
       {
         "Text": "Mauna Loa",
         "Correct": true,
-        "Comment": "Hawaii; Ausbruch 2022",
-        "Revealed": false
+        "Comment": "Hawaii; Ausbruch 2022"
       },
       {
         "Text": "Sakurajima",
         "Correct": true,
-        "Comment": "Japan; h\u00E4ufige Eruptionen",
-        "Revealed": false
+        "Comment": "Japan; häufige Eruptionen"
       },
       {
-        "Text": "Popocat\u00E9petl",
+        "Text": "Popocatépetl",
         "Correct": true,
-        "Comment": "Mexiko; aktiv",
-        "Revealed": false
+        "Comment": "Mexiko; aktiv"
       },
       {
-        "Text": "Eyjafjallaj\u00F6kull",
+        "Text": "Eyjafjallajökull",
         "Correct": true,
-        "Comment": "Island; Ausbruch 2010",
-        "Revealed": false
+        "Comment": "Island; Ausbruch 2010"
       },
       {
         "Text": "Mount St. Helens",
         "Correct": true,
-        "Comment": "USA; 1980, 2004\u201308",
-        "Revealed": false
+        "Comment": "USA; 1980, 2004–08"
       },
       {
         "Text": "Fuego",
         "Correct": true,
-        "Comment": "Guatemala; aktiv",
-        "Revealed": false
+        "Comment": "Guatemala; aktiv"
       },
       {
         "Text": "Kilimandscharo",
         "Correct": false,
-        "Comment": "ruhend/erloschen",
-        "Revealed": false
+        "Comment": "ruhend/erloschen"
       },
       {
         "Text": "Mount Everest",
         "Correct": false,
-        "Comment": "kein Vulkan",
-        "Revealed": false
+        "Comment": "kein Vulkan"
       },
       {
         "Text": "Uluru (Ayers Rock)",
         "Correct": false,
-        "Comment": "kein Vulkan",
-        "Revealed": false
+        "Comment": "kein Vulkan"
       },
       {
         "Text": "Zugspitze",
         "Correct": false,
-        "Comment": "kein Vulkan",
-        "Revealed": false
+        "Comment": "kein Vulkan"
       },
       {
         "Text": "Aconcagua",
         "Correct": false,
-        "Comment": "kein Vulkan",
-        "Revealed": false
+        "Comment": "kein Vulkan"
       },
       {
         "Text": "Ben Nevis",
         "Correct": false,
-        "Comment": "kein Vulkan",
-        "Revealed": false
+        "Comment": "kein Vulkan"
       }
     ]
   },
   {
-    "Text": "Wer komponierte im Zw\u00F6lftonstil (Dodekaphonie)?",
+    "Text": "Wer komponierte im Zwölftonstil (Dodekaphonie)?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "Arnold Sch\u00F6nberg",
+        "Text": "Arnold Schönberg",
         "Correct": true,
-        "Comment": "Begr\u00FCnder; 1920er",
-        "Revealed": false
+        "Comment": "Begründer; 1920er"
       },
       {
         "Text": "Anton Webern",
         "Correct": true,
-        "Comment": "Zweite Wiener Schule",
-        "Revealed": false
+        "Comment": "Zweite Wiener Schule"
       },
       {
         "Text": "Alban Berg",
         "Correct": true,
-        "Comment": "Zweite Wiener Schule",
-        "Revealed": false
+        "Comment": "Zweite Wiener Schule"
       },
       {
         "Text": "Ernst Krenek",
         "Correct": true,
-        "Comment": "ab sp\u00E4ten 1920ern",
-        "Revealed": false
+        "Comment": "ab späten 1920ern"
       },
       {
         "Text": "Luigi Dallapiccola",
         "Correct": true,
-        "Comment": "ital. Dodekaphonie",
-        "Revealed": false
+        "Comment": "ital. Dodekaphonie"
       },
       {
         "Text": "Milton Babbitt",
         "Correct": true,
-        "Comment": "US-Serialismus",
-        "Revealed": false
+        "Comment": "US-Serialismus"
       },
       {
         "Text": "Igor Strawinsky",
         "Correct": true,
-        "Comment": "sp\u00E4te Phase seriell",
-        "Revealed": false
+        "Comment": "späte Phase seriell"
       },
       {
         "Text": "Pierre Boulez",
         "Correct": true,
-        "Comment": "Serialismus",
-        "Revealed": false
+        "Comment": "Serialismus"
       },
       {
         "Text": "Johann Sebastian Bach",
         "Correct": false,
-        "Comment": "Barock; nicht dodekaphon",
-        "Revealed": false
+        "Comment": "Barock; nicht dodekaphon"
       },
       {
         "Text": "Giuseppe Verdi",
         "Correct": false,
-        "Comment": "Oper des 19. Jh.",
-        "Revealed": false
+        "Comment": "Oper des 19. Jh."
       },
       {
         "Text": "Richard Strauss",
         "Correct": false,
-        "Comment": "Sp\u00E4tromantik; nicht dodekaphon",
-        "Revealed": false
+        "Comment": "Spätromantik; nicht dodekaphon"
       },
       {
         "Text": "Sergei Rachmaninow",
         "Correct": false,
-        "Comment": "Sp\u00E4tromantik",
-        "Revealed": false
+        "Comment": "Spätromantik"
       },
       {
         "Text": "Pjotr Iljitsch Tschaikowski",
         "Correct": false,
-        "Comment": "Romantik",
-        "Revealed": false
+        "Comment": "Romantik"
       },
       {
         "Text": "Edward Elgar",
         "Correct": false,
-        "Comment": "Sp\u00E4tromantik",
-        "Revealed": false
+        "Comment": "Spätromantik"
       },
       {
         "Text": "Claude Debussy",
         "Correct": false,
-        "Comment": "Impressionismus",
-        "Revealed": false
+        "Comment": "Impressionismus"
       },
       {
         "Text": "Jean Sibelius",
         "Correct": false,
-        "Comment": "Sp\u00E4tromantik/Moderne",
-        "Revealed": false
+        "Comment": "Spätromantik/Moderne"
       }
     ]
   },
   {
-    "Text": "UNESCO-Welterbe in Deutschland: Welche St\u00E4tten sind gelistet?",
+    "Text": "UNESCO-Welterbe in Deutschland: Welche Stätten sind gelistet?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "K\u00F6lner Dom",
+        "Text": "Kölner Dom",
         "Correct": true,
-        "Comment": "seit 1996",
-        "Revealed": false
+        "Comment": "seit 1996"
       },
       {
         "Text": "Speyerer Dom",
         "Correct": true,
-        "Comment": "seit 1981",
-        "Revealed": false
+        "Comment": "seit 1981"
       },
       {
-        "Text": "Residenz W\u00FCrzburg",
+        "Text": "Residenz Würzburg",
         "Correct": true,
-        "Comment": "seit 1981",
-        "Revealed": false
+        "Comment": "seit 1981"
       },
       {
-        "Text": "Schl\u00F6sser Augustusburg und Falkenlust (Br\u00FChl)",
+        "Text": "Schlösser Augustusburg und Falkenlust (Brühl)",
         "Correct": true,
-        "Comment": "seit 1984",
-        "Revealed": false
+        "Comment": "seit 1984"
       },
       {
         "Text": "Museumsinsel Berlin",
         "Correct": true,
-        "Comment": "seit 1999",
-        "Revealed": false
+        "Comment": "seit 1999"
       },
       {
         "Text": "Bauhaus (Weimar/Dessau/Bernau)",
         "Correct": true,
-        "Comment": "seit 1996/2017 erweitert",
-        "Revealed": false
+        "Comment": "seit 1996/2017 erweitert"
       },
       {
         "Text": "Wartburg",
         "Correct": true,
-        "Comment": "seit 1999",
-        "Revealed": false
+        "Comment": "seit 1999"
       },
       {
         "Text": "Altstadt von Bamberg",
         "Correct": true,
-        "Comment": "seit 1993",
-        "Revealed": false
+        "Comment": "seit 1993"
       },
       {
-        "Text": "Altstadt von L\u00FCbeck",
+        "Text": "Altstadt von Lübeck",
         "Correct": true,
-        "Comment": "seit 1987",
-        "Revealed": false
+        "Comment": "seit 1987"
       },
       {
-        "Text": "V\u00F6lklinger H\u00FCtte",
+        "Text": "Völklinger Hütte",
         "Correct": true,
-        "Comment": "seit 1994",
-        "Revealed": false
+        "Comment": "seit 1994"
       },
       {
         "Text": "Oberes Mittelrheintal",
         "Correct": true,
-        "Comment": "seit 2002",
-        "Revealed": false
+        "Comment": "seit 2002"
       },
       {
         "Text": "Zeche Zollverein (Essen)",
         "Correct": true,
-        "Comment": "seit 2001",
-        "Revealed": false
+        "Comment": "seit 2001"
       },
       {
         "Text": "Neuschwanstein",
         "Correct": false,
-        "Comment": "nicht eingetragen",
-        "Revealed": false
+        "Comment": "nicht eingetragen"
       },
       {
         "Text": "Brandenburger Tor",
         "Correct": false,
-        "Comment": "kein eigener WH-Eintrag",
-        "Revealed": false
+        "Comment": "kein eigener WH-Eintrag"
       },
       {
         "Text": "Elbphilharmonie",
         "Correct": false,
-        "Comment": "kein WH-Status",
-        "Revealed": false
+        "Comment": "kein WH-Status"
       },
       {
         "Text": "Allianz Arena",
         "Correct": false,
-        "Comment": "kein WH-Status",
-        "Revealed": false
+        "Comment": "kein WH-Status"
       }
     ]
   },
@@ -18810,302 +15868,254 @@
       {
         "Text": "Leichtathletik",
         "Correct": true,
-        "Comment": "1896",
-        "Revealed": false
+        "Comment": "1896"
       },
       {
         "Text": "Radsport",
         "Correct": true,
-        "Comment": "1896",
-        "Revealed": false
+        "Comment": "1896"
       },
       {
         "Text": "Fechten",
         "Correct": true,
-        "Comment": "1896",
-        "Revealed": false
+        "Comment": "1896"
       },
       {
         "Text": "Turnen",
         "Correct": true,
-        "Comment": "1896",
-        "Revealed": false
+        "Comment": "1896"
       },
       {
-        "Text": "Schie\u00DFen",
+        "Text": "Schießen",
         "Correct": true,
-        "Comment": "1896",
-        "Revealed": false
+        "Comment": "1896"
       },
       {
         "Text": "Schwimmen",
         "Correct": true,
-        "Comment": "1896",
-        "Revealed": false
+        "Comment": "1896"
       },
       {
         "Text": "Tennis",
         "Correct": true,
-        "Comment": "1896",
-        "Revealed": false
+        "Comment": "1896"
       },
       {
         "Text": "Gewichtheben",
         "Correct": true,
-        "Comment": "1896",
-        "Revealed": false
+        "Comment": "1896"
       },
       {
-        "Text": "Ringen (griechisch-r\u00F6misch)",
+        "Text": "Ringen (griechisch-römisch)",
         "Correct": true,
-        "Comment": "1896",
-        "Revealed": false
+        "Comment": "1896"
       },
       {
-        "Text": "Fu\u00DFball",
+        "Text": "Fußball",
         "Correct": false,
-        "Comment": "nicht 1896",
-        "Revealed": false
+        "Comment": "nicht 1896"
       },
       {
         "Text": "Boxen",
         "Correct": false,
-        "Comment": "erst 1904",
-        "Revealed": false
+        "Comment": "erst 1904"
       },
       {
         "Text": "Rugby",
         "Correct": false,
-        "Comment": "erst 1900",
-        "Revealed": false
+        "Comment": "erst 1900"
       },
       {
         "Text": "Basketball",
         "Correct": false,
-        "Comment": "erst 1936",
-        "Revealed": false
+        "Comment": "erst 1936"
       },
       {
         "Text": "Eishockey",
         "Correct": false,
-        "Comment": "Winterspiele; nicht 1896",
-        "Revealed": false
+        "Comment": "Winterspiele; nicht 1896"
       },
       {
         "Text": "Rudern",
         "Correct": false,
-        "Comment": "1896 abgesagt (Wetter)",
-        "Revealed": false
+        "Comment": "1896 abgesagt (Wetter)"
       },
       {
         "Text": "Segeln",
         "Correct": false,
-        "Comment": "1896 abgesagt",
-        "Revealed": false
+        "Comment": "1896 abgesagt"
       }
     ]
   },
   {
-    "Text": "Aus der Antike stammende Philosophiebegriffe: Welche geh\u00F6ren dazu?",
+    "Text": "Aus der Antike stammende Philosophiebegriffe: Welche gehören dazu?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Stoizismus",
         "Correct": true,
-        "Comment": "antik (Stoa)",
-        "Revealed": false
+        "Comment": "antik (Stoa)"
       },
       {
         "Text": "Skepsis (Pyrrhonismus)",
         "Correct": true,
-        "Comment": "antik",
-        "Revealed": false
+        "Comment": "antik"
       },
       {
         "Text": "Eudaimonia",
         "Correct": true,
-        "Comment": "antik (Aristoteles)",
-        "Revealed": false
+        "Comment": "antik (Aristoteles)"
       },
       {
         "Text": "Arete (Tugend)",
         "Correct": true,
-        "Comment": "antik",
-        "Revealed": false
+        "Comment": "antik"
       },
       {
         "Text": "Logos",
         "Correct": true,
-        "Comment": "antik (Heraklit, Stoa)",
-        "Revealed": false
+        "Comment": "antik (Heraklit, Stoa)"
       },
       {
         "Text": "Dialektik",
         "Correct": true,
-        "Comment": "antik (Platon)",
-        "Revealed": false
+        "Comment": "antik (Platon)"
       },
       {
         "Text": "Atomismus",
         "Correct": true,
-        "Comment": "antik (Demokrit/Epikur)",
-        "Revealed": false
+        "Comment": "antik (Demokrit/Epikur)"
       },
       {
         "Text": "Katharsis",
         "Correct": true,
-        "Comment": "antik (Aristoteles)",
-        "Revealed": false
+        "Comment": "antik (Aristoteles)"
       },
       {
         "Text": "Eidos/Idee (Form)",
         "Correct": true,
-        "Comment": "antik (Platon)",
-        "Revealed": false
+        "Comment": "antik (Platon)"
       },
       {
         "Text": "Hedonismus",
         "Correct": true,
-        "Comment": "antik (Epikur)",
-        "Revealed": false
+        "Comment": "antik (Epikur)"
       },
       {
         "Text": "Kategorischer Imperativ",
         "Correct": false,
-        "Comment": "Kant; Neuzeit",
-        "Revealed": false
+        "Comment": "Kant; Neuzeit"
       },
       {
         "Text": "Utilitarismus",
         "Correct": false,
-        "Comment": "Bentham/Mill; Neuzeit",
-        "Revealed": false
+        "Comment": "Bentham/Mill; Neuzeit"
       },
       {
         "Text": "Existentialismus",
         "Correct": false,
-        "Comment": "20. Jh.",
-        "Revealed": false
+        "Comment": "20. Jh."
       },
       {
-        "Text": "Ph\u00E4nomenologie",
+        "Text": "Phänomenologie",
         "Correct": false,
-        "Comment": "Husserl; 20. Jh.",
-        "Revealed": false
+        "Comment": "Husserl; 20. Jh."
       },
       {
         "Text": "Dialektischer Materialismus",
         "Correct": false,
-        "Comment": "19.\u201320. Jh.",
-        "Revealed": false
+        "Comment": "19.–20. Jh."
       },
       {
         "Text": "Positivismus",
         "Correct": false,
-        "Comment": "Comte; 19. Jh.",
-        "Revealed": false
+        "Comment": "Comte; 19. Jh."
       }
     ]
   },
   {
-    "Text": "Z\u00E4hlen diese Sprachen zur indogermanischen Sprachfamilie?",
+    "Text": "Zählen diese Sprachen zur indogermanischen Sprachfamilie?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Deutsch",
         "Correct": true,
-        "Comment": "IE: germanisch",
-        "Revealed": false
+        "Comment": "IE: germanisch"
       },
       {
         "Text": "Finnisch",
         "Correct": false,
-        "Comment": "nicht IE: uralisch",
-        "Revealed": false
+        "Comment": "nicht IE: uralisch"
       },
       {
-        "Text": "T\u00FCrkisch",
+        "Text": "Türkisch",
         "Correct": false,
-        "Comment": "nicht IE: turksprachig",
-        "Revealed": false
+        "Comment": "nicht IE: turksprachig"
       },
       {
         "Text": "Englisch",
         "Correct": true,
-        "Comment": "IE: germanisch",
-        "Revealed": false
+        "Comment": "IE: germanisch"
       },
       {
         "Text": "Russisch",
         "Correct": true,
-        "Comment": "IE: slawisch",
-        "Revealed": false
+        "Comment": "IE: slawisch"
       },
       {
         "Text": "Arabisch",
         "Correct": false,
-        "Comment": "nicht IE: afroasiatisch",
-        "Revealed": false
+        "Comment": "nicht IE: afroasiatisch"
       },
       {
         "Text": "Polnisch",
         "Correct": true,
-        "Comment": "IE: slawisch",
-        "Revealed": false
+        "Comment": "IE: slawisch"
       },
       {
         "Text": "Ungarisch",
         "Correct": false,
-        "Comment": "nicht IE: uralisch",
-        "Revealed": false
+        "Comment": "nicht IE: uralisch"
       },
       {
         "Text": "Griechisch",
         "Correct": true,
-        "Comment": "IE: eigene Gruppe",
-        "Revealed": false
+        "Comment": "IE: eigene Gruppe"
       },
       {
         "Text": "Persisch (Farsi)",
         "Correct": true,
-        "Comment": "IE: iranisch",
-        "Revealed": false
+        "Comment": "IE: iranisch"
       },
       {
         "Text": "Hindi",
         "Correct": true,
-        "Comment": "IE: indoarisch",
-        "Revealed": false
+        "Comment": "IE: indoarisch"
       },
       {
         "Text": "Bengalisch",
         "Correct": true,
-        "Comment": "IE: indoarisch",
-        "Revealed": false
+        "Comment": "IE: indoarisch"
       },
       {
         "Text": "Armenisch",
         "Correct": true,
-        "Comment": "IE: eigene Gruppe",
-        "Revealed": false
+        "Comment": "IE: eigene Gruppe"
       },
       {
         "Text": "Albanisch",
         "Correct": true,
-        "Comment": "IE: eigene Gruppe",
-        "Revealed": false
+        "Comment": "IE: eigene Gruppe"
       },
       {
         "Text": "Walisisch",
         "Correct": true,
-        "Comment": "IE: keltisch",
-        "Revealed": false
+        "Comment": "IE: keltisch"
       },
       {
         "Text": "Baskisch",
         "Correct": false,
-        "Comment": "nicht IE: isolat",
-        "Revealed": false
+        "Comment": "nicht IE: isolat"
       }
     ]
   },
@@ -19116,914 +16126,770 @@
       {
         "Text": "Fall der Berliner Mauer",
         "Correct": true,
-        "Comment": "9. Nov 1989",
-        "Revealed": false
+        "Comment": "9. Nov 1989"
       },
       {
-        "Text": "Samtene Revolution (\u010CSSR)",
+        "Text": "Samtene Revolution (ČSSR)",
         "Correct": true,
-        "Comment": "Nov/Dez 1989",
-        "Revealed": false
+        "Comment": "Nov/Dez 1989"
       },
       {
-        "Text": "Rum\u00E4nische Revolution",
+        "Text": "Rumänische Revolution",
         "Correct": true,
-        "Comment": "Dez 1989",
-        "Revealed": false
+        "Comment": "Dez 1989"
       },
       {
         "Text": "Deutsche Einheit",
         "Correct": true,
-        "Comment": "3. Okt 1990",
-        "Revealed": false
+        "Comment": "3. Okt 1990"
       },
       {
         "Text": "Zwei-plus-Vier-Vertrag",
         "Correct": true,
-        "Comment": "Sept 1990",
-        "Revealed": false
+        "Comment": "Sept 1990"
       },
       {
-        "Text": "Ungarn \u00F6ffnet Grenze (Paneurop. Picknick)",
+        "Text": "Ungarn öffnet Grenze (Paneurop. Picknick)",
         "Correct": true,
-        "Comment": "Aug 1989",
-        "Revealed": false
+        "Comment": "Aug 1989"
       },
       {
         "Text": "Baltischer Weg (Menschenkette)",
         "Correct": true,
-        "Comment": "23. Aug 1989",
-        "Revealed": false
+        "Comment": "23. Aug 1989"
       },
       {
         "Text": "Teilfreie Wahlen in Polen",
         "Correct": true,
-        "Comment": "Juni 1989",
-        "Revealed": false
+        "Comment": "Juni 1989"
       },
       {
-        "Text": "V\u00E1clav Havel wird Pr\u00E4sident",
+        "Text": "Václav Havel wird Präsident",
         "Correct": true,
-        "Comment": "Dez 1989",
-        "Revealed": false
+        "Comment": "Dez 1989"
       },
       {
-        "Text": "Litauen erkl\u00E4rt Unabh\u00E4ngigkeit",
+        "Text": "Litauen erklärt Unabhängigkeit",
         "Correct": true,
-        "Comment": "11. M\u00E4rz 1990",
-        "Revealed": false
+        "Comment": "11. März 1990"
       },
       {
-        "Text": "Aufl\u00F6sung des Warschauer Pakts",
+        "Text": "Auflösung des Warschauer Pakts",
         "Correct": false,
-        "Comment": "1991",
-        "Revealed": false
+        "Comment": "1991"
       },
       {
         "Text": "Vertrag von Maastricht",
         "Correct": false,
-        "Comment": "1992",
-        "Revealed": false
+        "Comment": "1992"
       },
       {
-        "Text": "Euro-Einf\u00FChrung",
+        "Text": "Euro-Einführung",
         "Correct": false,
-        "Comment": "1999/2002",
-        "Revealed": false
+        "Comment": "1999/2002"
       },
       {
         "Text": "Beginn der Jugoslawienkriege",
         "Correct": false,
-        "Comment": "1991",
-        "Revealed": false
+        "Comment": "1991"
       },
       {
         "Text": "Tschernobyl-Katastrophe",
         "Correct": false,
-        "Comment": "1986",
-        "Revealed": false
+        "Comment": "1986"
       },
       {
         "Text": "Brexit-Referendum",
         "Correct": false,
-        "Comment": "2016",
-        "Revealed": false
+        "Comment": "2016"
       }
     ]
   },
   {
-    "Text": "Wer gab ber\u00FChmten mathematischen S\u00E4tzen seinen Namen?",
+    "Text": "Wer gab berühmten mathematischen Sätzen seinen Namen?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Pythagoras",
         "Correct": true,
-        "Comment": "Satz des Pythagoras",
-        "Revealed": false
+        "Comment": "Satz des Pythagoras"
       },
       {
         "Text": "Fermat",
         "Correct": true,
-        "Comment": "Fermats letzter Satz",
-        "Revealed": false
+        "Comment": "Fermats letzter Satz"
       },
       {
         "Text": "Gauss",
         "Correct": true,
-        "Comment": "Gau\u00DFscher Integralsatz u. a.",
-        "Revealed": false
+        "Comment": "Gaußscher Integralsatz u. a."
       },
       {
         "Text": "Green",
         "Correct": true,
-        "Comment": "Greenscher Satz",
-        "Revealed": false
+        "Comment": "Greenscher Satz"
       },
       {
         "Text": "Stokes",
         "Correct": true,
-        "Comment": "Stokesscher Satz",
-        "Revealed": false
+        "Comment": "Stokesscher Satz"
       },
       {
         "Text": "Cauchy",
         "Correct": true,
-        "Comment": "S\u00E4tze von Cauchy",
-        "Revealed": false
+        "Comment": "Sätze von Cauchy"
       },
       {
         "Text": "Lagrange",
         "Correct": true,
-        "Comment": "Satz von Lagrange",
-        "Revealed": false
+        "Comment": "Satz von Lagrange"
       },
       {
         "Text": "Bayes",
         "Correct": true,
-        "Comment": "Satz von Bayes",
-        "Revealed": false
+        "Comment": "Satz von Bayes"
       },
       {
         "Text": "Noether",
         "Correct": true,
-        "Comment": "Noethers Theorem",
-        "Revealed": false
+        "Comment": "Noethers Theorem"
       },
       {
         "Text": "Euler",
         "Correct": true,
-        "Comment": "Eulerscher Polyedersatz u. a.",
-        "Revealed": false
+        "Comment": "Eulerscher Polyedersatz u. a."
       },
       {
         "Text": "Cantor",
         "Correct": true,
-        "Comment": "Cantors Satz",
-        "Revealed": false
+        "Comment": "Cantors Satz"
       },
       {
-        "Text": "G\u00F6del",
+        "Text": "Gödel",
         "Correct": true,
-        "Comment": "Unvollst\u00E4ndigkeitss\u00E4tze",
-        "Revealed": false
+        "Comment": "Unvollständigkeitssätze"
       },
       {
         "Text": "Faraday",
         "Correct": false,
-        "Comment": "Physiker; kein eponymes Mathe-Theorem",
-        "Revealed": false
+        "Comment": "Physiker; kein eponymes Mathe-Theorem"
       },
       {
         "Text": "Darwin",
         "Correct": false,
-        "Comment": "Biologe",
-        "Revealed": false
+        "Comment": "Biologe"
       },
       {
         "Text": "Mendelejew",
         "Correct": false,
-        "Comment": "Chemiker",
-        "Revealed": false
+        "Comment": "Chemiker"
       },
       {
         "Text": "Pasteur",
         "Correct": false,
-        "Comment": "Chemiker/Mikrobiologe",
-        "Revealed": false
+        "Comment": "Chemiker/Mikrobiologe"
       }
     ]
   },
   {
-    "Text": "Aus Giuseppe Verdis Feder \u2013 welche Operntitel geh\u00F6ren dazu?",
+    "Text": "Aus Giuseppe Verdis Feder – welche Operntitel gehören dazu?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Aida",
         "Correct": true,
-        "Comment": "1871",
-        "Revealed": false
+        "Comment": "1871"
       },
       {
         "Text": "La Traviata",
         "Correct": true,
-        "Comment": "1853",
-        "Revealed": false
+        "Comment": "1853"
       },
       {
         "Text": "Rigoletto",
         "Correct": true,
-        "Comment": "1851",
-        "Revealed": false
+        "Comment": "1851"
       },
       {
         "Text": "Il Trovatore",
         "Correct": true,
-        "Comment": "1853",
-        "Revealed": false
+        "Comment": "1853"
       },
       {
         "Text": "Nabucco",
         "Correct": true,
-        "Comment": "1842",
-        "Revealed": false
+        "Comment": "1842"
       },
       {
         "Text": "Otello",
         "Correct": true,
-        "Comment": "1887",
-        "Revealed": false
+        "Comment": "1887"
       },
       {
         "Text": "Falstaff",
         "Correct": true,
-        "Comment": "1893",
-        "Revealed": false
+        "Comment": "1893"
       },
       {
         "Text": "Macbeth",
         "Correct": true,
-        "Comment": "1847/65",
-        "Revealed": false
+        "Comment": "1847/65"
       },
       {
         "Text": "Don Carlos",
         "Correct": true,
-        "Comment": "1867",
-        "Revealed": false
+        "Comment": "1867"
       },
       {
         "Text": "Un ballo in maschera",
         "Correct": true,
-        "Comment": "1859",
-        "Revealed": false
+        "Comment": "1859"
       },
       {
         "Text": "Simon Boccanegra",
         "Correct": true,
-        "Comment": "1857/81",
-        "Revealed": false
+        "Comment": "1857/81"
       },
       {
         "Text": "Luisa Miller",
         "Correct": true,
-        "Comment": "1849",
-        "Revealed": false
+        "Comment": "1849"
       },
       {
         "Text": "Carmen",
         "Correct": false,
-        "Comment": "Bizet",
-        "Revealed": false
+        "Comment": "Bizet"
       },
       {
         "Text": "Tosca",
         "Correct": false,
-        "Comment": "Puccini",
-        "Revealed": false
+        "Comment": "Puccini"
       },
       {
-        "Text": "Die Zauberfl\u00F6te",
+        "Text": "Die Zauberflöte",
         "Correct": false,
-        "Comment": "Mozart",
-        "Revealed": false
+        "Comment": "Mozart"
       },
       {
         "Text": "Der Barbier von Sevilla",
         "Correct": false,
-        "Comment": "Rossini",
-        "Revealed": false
+        "Comment": "Rossini"
       }
     ]
   },
   {
-    "Text": "Hinter dem \u201EEisernen Vorhang\u201C: Welche St\u00E4dte lagen bis 1989 im Ostblock?",
+    "Text": "Hinter dem „Eisernen Vorhang“: Welche Städte lagen bis 1989 im Ostblock?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Ost-Berlin",
         "Correct": true,
-        "Comment": "DDR",
-        "Revealed": false
+        "Comment": "DDR"
       },
       {
         "Text": "Prag",
         "Correct": true,
-        "Comment": "\u010CSSR",
-        "Revealed": false
+        "Comment": "ČSSR"
       },
       {
         "Text": "Warschau",
         "Correct": true,
-        "Comment": "Polen",
-        "Revealed": false
+        "Comment": "Polen"
       },
       {
         "Text": "Budapest",
         "Correct": true,
-        "Comment": "Ungarn",
-        "Revealed": false
+        "Comment": "Ungarn"
       },
       {
         "Text": "Bukarest",
         "Correct": true,
-        "Comment": "Rum\u00E4nien",
-        "Revealed": false
+        "Comment": "Rumänien"
       },
       {
         "Text": "Sofia",
         "Correct": true,
-        "Comment": "Bulgarien",
-        "Revealed": false
+        "Comment": "Bulgarien"
       },
       {
         "Text": "Leipzig",
         "Correct": true,
-        "Comment": "DDR",
-        "Revealed": false
+        "Comment": "DDR"
       },
       {
         "Text": "Dresden",
         "Correct": true,
-        "Comment": "DDR",
-        "Revealed": false
+        "Comment": "DDR"
       },
       {
         "Text": "Leningrad",
         "Correct": true,
-        "Comment": "UdSSR; heute St. Petersburg",
-        "Revealed": false
+        "Comment": "UdSSR; heute St. Petersburg"
       },
       {
         "Text": "Kiew (Kyiv)",
         "Correct": true,
-        "Comment": "UdSSR; heute Ukraine",
-        "Revealed": false
+        "Comment": "UdSSR; heute Ukraine"
       },
       {
         "Text": "Riga",
         "Correct": true,
-        "Comment": "UdSSR; heute Lettland",
-        "Revealed": false
+        "Comment": "UdSSR; heute Lettland"
       },
       {
         "Text": "Vilnius",
         "Correct": true,
-        "Comment": "UdSSR; heute Litauen",
-        "Revealed": false
+        "Comment": "UdSSR; heute Litauen"
       },
       {
         "Text": "Bonn",
         "Correct": false,
-        "Comment": "BRD (West)",
-        "Revealed": false
+        "Comment": "BRD (West)"
       },
       {
         "Text": "Paris",
         "Correct": false,
-        "Comment": "Frankreich (West)",
-        "Revealed": false
+        "Comment": "Frankreich (West)"
       },
       {
-        "Text": "M\u00FCnchen",
+        "Text": "München",
         "Correct": false,
-        "Comment": "BRD (West)",
-        "Revealed": false
+        "Comment": "BRD (West)"
       },
       {
         "Text": "Wien",
         "Correct": false,
-        "Comment": "neutral/West",
-        "Revealed": false
+        "Comment": "neutral/West"
       }
     ]
   },
   {
-    "Text": "Zwischen 1600 und 1800 entwickelt oder ma\u00DFgeblich eingef\u00FChrt \u2013 welche Messger\u00E4te/Instrumente?",
+    "Text": "Zwischen 1600 und 1800 entwickelt oder maßgeblich eingeführt – welche Messgeräte/Instrumente?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Fernrohr (Teleskop)",
         "Correct": true,
-        "Comment": "ab 1608",
-        "Revealed": false
+        "Comment": "ab 1608"
       },
       {
         "Text": "Mikroskop",
         "Correct": true,
-        "Comment": "fr\u00FChes 17. Jh.",
-        "Revealed": false
+        "Comment": "frühes 17. Jh."
       },
       {
         "Text": "Barometer",
         "Correct": true,
-        "Comment": "Torricelli 1643",
-        "Revealed": false
+        "Comment": "Torricelli 1643"
       },
       {
         "Text": "Quecksilberthermometer",
         "Correct": true,
-        "Comment": "Fahrenheit 1714",
-        "Revealed": false
+        "Comment": "Fahrenheit 1714"
       },
       {
         "Text": "Pendeluhr",
         "Correct": true,
-        "Comment": "Huygens 1656",
-        "Revealed": false
+        "Comment": "Huygens 1656"
       },
       {
         "Text": "Luftpumpe (Vakuumpumpe)",
         "Correct": true,
-        "Comment": "Boyle/Hooke 1650er",
-        "Revealed": false
+        "Comment": "Boyle/Hooke 1650er"
       },
       {
         "Text": "Sextant",
         "Correct": true,
-        "Comment": "1757",
-        "Revealed": false
+        "Comment": "1757"
       },
       {
         "Text": "Marinechronometer",
         "Correct": true,
-        "Comment": "Harrison 1760er",
-        "Revealed": false
+        "Comment": "Harrison 1760er"
       },
       {
         "Text": "Leydener Flasche",
         "Correct": true,
-        "Comment": "1745/46",
-        "Revealed": false
+        "Comment": "1745/46"
       },
       {
         "Text": "Goldblatt-Elektroskop",
         "Correct": true,
-        "Comment": "Bennet 1787",
-        "Revealed": false
+        "Comment": "Bennet 1787"
       },
       {
         "Text": "Atwoods Fallmaschine",
         "Correct": true,
-        "Comment": "1784",
-        "Revealed": false
+        "Comment": "1784"
       },
       {
-        "Text": "Voltasche S\u00E4ule",
+        "Text": "Voltasche Säule",
         "Correct": true,
-        "Comment": "1800",
-        "Revealed": false
+        "Comment": "1800"
       },
       {
         "Text": "Galvanometer",
         "Correct": false,
-        "Comment": "ab 1820",
-        "Revealed": false
+        "Comment": "ab 1820"
       },
       {
         "Text": "Elektrischer Telegraph",
         "Correct": false,
-        "Comment": "1830er",
-        "Revealed": false
+        "Comment": "1830er"
       },
       {
         "Text": "Fotografie (Daguerreotypie)",
         "Correct": false,
-        "Comment": "1839",
-        "Revealed": false
+        "Comment": "1839"
       },
       {
         "Text": "Dynamo (Generator)",
         "Correct": false,
-        "Comment": "1860er",
-        "Revealed": false
+        "Comment": "1860er"
       }
     ]
   },
   {
-    "Text": "Wer geh\u00F6rte dem Warschauer Pakt an?",
+    "Text": "Wer gehörte dem Warschauer Pakt an?",
     "Selected": false,
     "Answers": [
       {
         "Text": "UdSSR",
         "Correct": true,
-        "Comment": "Mitglied ab 1955",
-        "Revealed": false
+        "Comment": "Mitglied ab 1955"
       },
       {
         "Text": "Polen",
         "Correct": true,
-        "Comment": "Mitglied ab 1955",
-        "Revealed": false
+        "Comment": "Mitglied ab 1955"
       },
       {
         "Text": "DDR",
         "Correct": true,
-        "Comment": "Mitglied ab 1955",
-        "Revealed": false
+        "Comment": "Mitglied ab 1955"
       },
       {
         "Text": "Tschechoslowakei",
         "Correct": true,
-        "Comment": "Mitglied ab 1955",
-        "Revealed": false
+        "Comment": "Mitglied ab 1955"
       },
       {
         "Text": "Ungarn",
         "Correct": true,
-        "Comment": "Mitglied ab 1955",
-        "Revealed": false
+        "Comment": "Mitglied ab 1955"
       },
       {
-        "Text": "Rum\u00E4nien",
+        "Text": "Rumänien",
         "Correct": true,
-        "Comment": "Mitglied ab 1955",
-        "Revealed": false
+        "Comment": "Mitglied ab 1955"
       },
       {
         "Text": "Bulgarien",
         "Correct": true,
-        "Comment": "Mitglied ab 1955",
-        "Revealed": false
+        "Comment": "Mitglied ab 1955"
       },
       {
         "Text": "Albanien",
         "Correct": true,
-        "Comment": "1955\u20131968",
-        "Revealed": false
+        "Comment": "1955–1968"
       },
       {
         "Text": "Jugoslawien",
         "Correct": false,
-        "Comment": "kein Mitglied",
-        "Revealed": false
+        "Comment": "kein Mitglied"
       },
       {
-        "Text": "\u00D6sterreich",
+        "Text": "Österreich",
         "Correct": false,
-        "Comment": "neutral; kein Mitglied",
-        "Revealed": false
+        "Comment": "neutral; kein Mitglied"
       },
       {
         "Text": "Finnland",
         "Correct": false,
-        "Comment": "kein Mitglied",
-        "Revealed": false
+        "Comment": "kein Mitglied"
       },
       {
         "Text": "Norwegen",
         "Correct": false,
-        "Comment": "NATO; kein Mitglied",
-        "Revealed": false
+        "Comment": "NATO; kein Mitglied"
       },
       {
         "Text": "Griechenland",
         "Correct": false,
-        "Comment": "NATO; kein Mitglied",
-        "Revealed": false
+        "Comment": "NATO; kein Mitglied"
       },
       {
-        "Text": "T\u00FCrkei",
+        "Text": "Türkei",
         "Correct": false,
-        "Comment": "NATO; kein Mitglied",
-        "Revealed": false
+        "Comment": "NATO; kein Mitglied"
       },
       {
         "Text": "Spanien",
         "Correct": false,
-        "Comment": "kein Mitglied",
-        "Revealed": false
+        "Comment": "kein Mitglied"
       },
       {
         "Text": "China (VR China)",
         "Correct": false,
-        "Comment": "kein Mitglied",
-        "Revealed": false
+        "Comment": "kein Mitglied"
       }
     ]
   },
   {
-    "Text": "An der Ostseek\u00FCste gelegen \u2013 welche St\u00E4dte trifft das zu?",
+    "Text": "An der Ostseeküste gelegen – welche Städte trifft das zu?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "L\u00FCbeck",
+        "Text": "Lübeck",
         "Correct": true,
-        "Comment": "DE; Ostsee",
-        "Revealed": false
+        "Comment": "DE; Ostsee"
       },
       {
         "Text": "Rostock",
         "Correct": true,
-        "Comment": "DE; Ostsee",
-        "Revealed": false
+        "Comment": "DE; Ostsee"
       },
       {
         "Text": "Kiel",
         "Correct": true,
-        "Comment": "DE; Ostsee",
-        "Revealed": false
+        "Comment": "DE; Ostsee"
       },
       {
-        "Text": "Gda\u0144sk (Danzig)",
+        "Text": "Gdańsk (Danzig)",
         "Correct": true,
-        "Comment": "PL; Ostsee",
-        "Revealed": false
+        "Comment": "PL; Ostsee"
       },
       {
         "Text": "Gdynia",
         "Correct": true,
-        "Comment": "PL; Ostsee",
-        "Revealed": false
+        "Comment": "PL; Ostsee"
       },
       {
         "Text": "Kaliningrad",
         "Correct": true,
-        "Comment": "RU; Ostsee",
-        "Revealed": false
+        "Comment": "RU; Ostsee"
       },
       {
-        "Text": "Klaip\u0117da",
+        "Text": "Klaipėda",
         "Correct": true,
-        "Comment": "LT; Ostsee",
-        "Revealed": false
+        "Comment": "LT; Ostsee"
       },
       {
         "Text": "Riga",
         "Correct": true,
-        "Comment": "LV; Ostsee",
-        "Revealed": false
+        "Comment": "LV; Ostsee"
       },
       {
         "Text": "Tallinn",
         "Correct": true,
-        "Comment": "EE; Ostsee",
-        "Revealed": false
+        "Comment": "EE; Ostsee"
       },
       {
         "Text": "Sankt Petersburg",
         "Correct": true,
-        "Comment": "RU; Finnischer Meerbusen",
-        "Revealed": false
+        "Comment": "RU; Finnischer Meerbusen"
       },
       {
         "Text": "Turku",
         "Correct": true,
-        "Comment": "FI; Ostsee",
-        "Revealed": false
+        "Comment": "FI; Ostsee"
       },
       {
         "Text": "Stralsund",
         "Correct": true,
-        "Comment": "DE; Ostsee",
-        "Revealed": false
+        "Comment": "DE; Ostsee"
       },
       {
         "Text": "Hamburg",
         "Correct": false,
-        "Comment": "Elbe/Nordsee",
-        "Revealed": false
+        "Comment": "Elbe/Nordsee"
       },
       {
         "Text": "Amsterdam",
         "Correct": false,
-        "Comment": "Nordsee",
-        "Revealed": false
+        "Comment": "Nordsee"
       },
       {
         "Text": "Oslo",
         "Correct": false,
-        "Comment": "Oslofjord/Skagerrak",
-        "Revealed": false
+        "Comment": "Oslofjord/Skagerrak"
       },
       {
         "Text": "Bergen",
         "Correct": false,
-        "Comment": "Atlantik/Nordsee",
-        "Revealed": false
+        "Comment": "Atlantik/Nordsee"
       }
     ]
   },
   {
-    "Text": "Von Shakespeare \u2013 welche Titel sind tats\u00E4chlich seine St\u00FCcke?",
+    "Text": "Von Shakespeare – welche Titel sind tatsächlich seine Stücke?",
     "Selected": false,
     "Answers": [
       {
         "Text": "Hamlet",
         "Correct": true,
-        "Comment": "Trag\u00F6die",
-        "Revealed": false
+        "Comment": "Tragödie"
       },
       {
         "Text": "Macbeth",
         "Correct": true,
-        "Comment": "Trag\u00F6die",
-        "Revealed": false
+        "Comment": "Tragödie"
       },
       {
         "Text": "Othello",
         "Correct": true,
-        "Comment": "Trag\u00F6die",
-        "Revealed": false
+        "Comment": "Tragödie"
       },
       {
-        "Text": "K\u00F6nig Lear",
+        "Text": "König Lear",
         "Correct": true,
-        "Comment": "Trag\u00F6die",
-        "Revealed": false
+        "Comment": "Tragödie"
       },
       {
         "Text": "Romeo und Julia",
         "Correct": true,
-        "Comment": "Trag\u00F6die",
-        "Revealed": false
+        "Comment": "Tragödie"
       },
       {
         "Text": "Der Sturm (The Tempest)",
         "Correct": true,
-        "Comment": "Romanze/Sp\u00E4twerk",
-        "Revealed": false
+        "Comment": "Romanze/Spätwerk"
       },
       {
         "Text": "Ein Sommernachtstraum",
         "Correct": true,
-        "Comment": "Kom\u00F6die",
-        "Revealed": false
+        "Comment": "Komödie"
       },
       {
-        "Text": "Viel L\u00E4rm um Nichts",
+        "Text": "Viel Lärm um Nichts",
         "Correct": true,
-        "Comment": "Kom\u00F6die",
-        "Revealed": false
+        "Comment": "Komödie"
       },
       {
         "Text": "Was ihr wollt (Twelfth Night)",
         "Correct": true,
-        "Comment": "Kom\u00F6die",
-        "Revealed": false
+        "Comment": "Komödie"
       },
       {
-        "Text": "Julius C\u00E4sar",
+        "Text": "Julius Cäsar",
         "Correct": true,
-        "Comment": "Trag\u00F6die",
-        "Revealed": false
+        "Comment": "Tragödie"
       },
       {
         "Text": "Faust",
         "Correct": false,
-        "Comment": "Goethe",
-        "Revealed": false
+        "Comment": "Goethe"
       },
       {
         "Text": "Der eingebildete Kranke",
         "Correct": false,
-        "Comment": "Moli\u00E8re",
-        "Revealed": false
+        "Comment": "Molière"
       },
       {
         "Text": "Warten auf Godot",
         "Correct": false,
-        "Comment": "Beckett",
-        "Revealed": false
+        "Comment": "Beckett"
       },
       {
         "Text": "Drei Schwestern",
         "Correct": false,
-        "Comment": "Tschechow",
-        "Revealed": false
+        "Comment": "Tschechow"
       },
       {
         "Text": "Die Physiker",
         "Correct": false,
-        "Comment": "D\u00FCrrenmatt",
-        "Revealed": false
+        "Comment": "Dürrenmatt"
       },
       {
-        "Text": "Die Zauberfl\u00F6te",
+        "Text": "Die Zauberflöte",
         "Correct": false,
-        "Comment": "Mozart (Oper)",
-        "Revealed": false
+        "Comment": "Mozart (Oper)"
       }
     ]
   },
   {
-    "Text": "Welche Staaten z\u00E4hlen zu den Alpenl\u00E4ndern (im Bereich des Alpenbogens)?",
+    "Text": "Welche Staaten zählen zu den Alpenländern (im Bereich des Alpenbogens)?",
     "Selected": false,
     "Answers": [
       {
-        "Text": "\u00D6sterreich",
+        "Text": "Österreich",
         "Correct": true,
-        "Comment": "Alpenstaat",
-        "Revealed": false
+        "Comment": "Alpenstaat"
       },
       {
         "Text": "Deutschland",
         "Correct": true,
-        "Comment": "Alpenanteil (Bayern)",
-        "Revealed": false
+        "Comment": "Alpenanteil (Bayern)"
       },
       {
         "Text": "Frankreich",
         "Correct": true,
-        "Comment": "Alpenstaat",
-        "Revealed": false
+        "Comment": "Alpenstaat"
       },
       {
         "Text": "Italien",
         "Correct": true,
-        "Comment": "Alpenstaat",
-        "Revealed": false
+        "Comment": "Alpenstaat"
       },
       {
         "Text": "Schweiz",
         "Correct": true,
-        "Comment": "Alpenstaat",
-        "Revealed": false
+        "Comment": "Alpenstaat"
       },
       {
         "Text": "Slowenien",
         "Correct": true,
-        "Comment": "Alpenstaat",
-        "Revealed": false
+        "Comment": "Alpenstaat"
       },
       {
         "Text": "Liechtenstein",
         "Correct": true,
-        "Comment": "Alpenstaat",
-        "Revealed": false
+        "Comment": "Alpenstaat"
       },
       {
         "Text": "Monaco",
         "Correct": true,
-        "Comment": "Maritime Alpen; Kleinstaat",
-        "Revealed": false
+        "Comment": "Maritime Alpen; Kleinstaat"
       },
       {
         "Text": "Spanien",
         "Correct": false,
-        "Comment": "Pyren\u00E4en, nicht Alpen",
-        "Revealed": false
+        "Comment": "Pyrenäen, nicht Alpen"
       },
       {
         "Text": "Polen",
         "Correct": false,
-        "Comment": "Karpaten, nicht Alpen",
-        "Revealed": false
+        "Comment": "Karpaten, nicht Alpen"
       },
       {
         "Text": "Tschechien",
         "Correct": false,
-        "Comment": "keine Alpen",
-        "Revealed": false
+        "Comment": "keine Alpen"
       },
       {
         "Text": "Ungarn",
         "Correct": false,
-        "Comment": "keine Alpen",
-        "Revealed": false
+        "Comment": "keine Alpen"
       },
       {
         "Text": "Kroatien",
         "Correct": false,
-        "Comment": "Dinariden; nicht Alpen",
-        "Revealed": false
+        "Comment": "Dinariden; nicht Alpen"
       },
       {
         "Text": "Slowakei",
         "Correct": false,
-        "Comment": "Karpaten; nicht Alpen",
-        "Revealed": false
+        "Comment": "Karpaten; nicht Alpen"
       },
       {
         "Text": "Serbien",
         "Correct": false,
-        "Comment": "keine Alpen",
-        "Revealed": false
+        "Comment": "keine Alpen"
       },
       {
         "Text": "Belgien",
         "Correct": false,
-        "Comment": "keine Alpen",
-        "Revealed": false
+        "Comment": "keine Alpen"
       }
     ]
   }

--- a/Models/Answer.cs
+++ b/Models/Answer.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 namespace RiskierWas.Models
 {
@@ -12,6 +13,7 @@ namespace RiskierWas.Models
         public string Text { get => _text; set { _text = value; OnPropertyChanged(nameof(Text)); } }
         public bool Correct { get => _correct; set { _correct = value; OnPropertyChanged(nameof(Correct)); } }
         public string? Comment { get => _comment; set { _comment = value; OnPropertyChanged(nameof(Comment)); } }
+        [JsonIgnore]
         public bool Revealed { get => _revealed; set { _revealed = value; OnPropertyChanged(nameof(Revealed)); } }
 
         public event PropertyChangedEventHandler? PropertyChanged;


### PR DESCRIPTION
## Summary
- drop unused `Revealed` property from question data file
- keep runtime `Revealed` state in `Answer` but ignore it during JSON serialization

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update -y -qq && apt-get install -y -qq dotnet-sdk-7.0` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a55174cf2c8321886003d0c80f820e