### PR TITLE
Add authorship note on start screen

### DIFF
--- a/Views/StartView.xaml
+++ b/Views/StartView.xaml
@@ -12,6 +12,8 @@
             <!-- Header -->
             <RowDefinition Height="*"/>
             <!-- Inhalt -->
+            <RowDefinition Height="Auto"/>
+            <!-- Fußzeile -->
         </Grid.RowDefinitions>
 
         <!-- HEADER: Logo + Erklärung -->
@@ -133,5 +135,13 @@
                 </Border>
             </StackPanel>
         </Grid>
+
+        <!-- Fußzeile: Hinweis zur Urheberschaft -->
+        <TextBlock Grid.Row="2"
+                   Text="nach einer tollen Excel-Makro-Vorlage von Thommy Volz programmiert von Matthias Zimmer + ChatGPT"
+                   Foreground="Gray"
+                   HorizontalAlignment="Center"
+                   Margin="0,8,0,8"
+                   FontSize="12"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- Add authorship footnote to StartView footer acknowledging Thommy Volz's Excel macro template and programming by Matthias Zimmer with ChatGPT.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a772701fa483218727f57693d811be