### PR TITLE
Add pause button for point decay

### DIFF
--- a/Views/GameView.xaml
+++ b/Views/GameView.xaml
@@ -186,6 +186,8 @@
                 </TextBlock>
             </StackPanel>
             <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                <Button Content="{Binding PauseButtonText}" Command="{Binding ToggleDecayPauseCommand}" Margin="6,0"
+                        Visibility="{Binding EnablePointDecay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                 <Button Content="Weitergeben" Command="{Binding PassTurnCommand}" Margin="6,0"/>
                 <Button Content="Nächste Frage" Command="{Binding NextQuestionCommand}" Margin="6,0"/>
                 <Button Content="Zurück" Command="{Binding BackToStartCommand}" Margin="6,0"/>


### PR DESCRIPTION
## Summary
- Add pause state and toggle command in `GameViewModel` to control point decay timer.
- Show a pause/resume button in `GameView` when point decay is enabled.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a94cfdd8dc8321a4dc0d66286eb688