### PR TITLE
Add decay progress bar

### DIFF
--- a/Views/GameView.xaml
+++ b/Views/GameView.xaml
@@ -179,6 +179,7 @@
         <!-- Footer / Controls -->
         <DockPanel Grid.Row="3" Panel.ZIndex="10" Margin="0,12,0,0">
             <StackPanel Orientation="Vertical">
+                <ProgressBar Height="6" Margin="0,0,0,4" Minimum="0" Maximum="1" Value="{Binding DecayProgress, Mode=OneWay}" Visibility="{Binding EnablePointDecay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                 <TextBlock Text="{Binding InfoLine}" Margin="0,0,16,2"/>
                 <TextBlock>
                     <Run Text="Punkte aktuelle Runde: "/>


### PR DESCRIPTION
## Summary
- show small progress bar indicating time until next point decay
- track decay timer progress in `GameViewModel`
- bind progress bar value one-way to prevent runtime binding errors

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when fetching packages)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a94ef9d08083218fafaf8197f1a6b3