### PR TITLE
Show point-decay progress in next-answer tile

### DIFF
--- a/Views/GameView.xaml
+++ b/Views/GameView.xaml
@@ -84,6 +84,10 @@
                 <StackPanel>
                     <TextBlock Text="Nächste richtige Antwort:" Foreground="White"/>
                     <TextBlock Text="{Binding NextPoints}" Foreground="LightGreen" FontSize="24"/>
+                    <!-- Fortschrittsbalken für Punkteverfall direkt unter den Punkten -->
+                    <ProgressBar Height="6" Margin="0,4,0,0" Minimum="0" Maximum="1"
+                                 Value="{Binding DecayProgress}"
+                                 Visibility="{Binding EnablePointDecay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                 </StackPanel>
             </Border>
             <Border CornerRadius="12" Padding="12" Margin="8,0,0,0" Background="#1F2937">
@@ -179,7 +183,6 @@
         <!-- Footer / Controls -->
         <DockPanel Grid.Row="3" Panel.ZIndex="10" Margin="0,12,0,0">
             <StackPanel Orientation="Vertical">
-                <ProgressBar Height="6" Margin="0,0,0,4" Minimum="0" Maximum="1" Value="{Binding DecayProgress}" Visibility="{Binding EnablePointDecay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                 <TextBlock Text="{Binding InfoLine}" Margin="0,0,16,2"/>
                 <TextBlock>
                     <Run Text="Punkte aktuelle Runde: "/>


### PR DESCRIPTION
## Summary
- Move point-decay progress bar into the "next answer" tile for clearer tracking
- Remove old footer progress bar

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6eafc310832180e2f48e3e44f20f